### PR TITLE
fix: add plugin entry point

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "android",
     "ios",
     "cpp",
+    "plugin.js",
     "*.podspec",
     "!lib/typescript/example",
     "!ios/build",

--- a/plugin.js
+++ b/plugin.js
@@ -1,0 +1,1 @@
+module.exports = require("./src/plugin");


### PR DESCRIPTION
Add the plugin entry point that just re-exports it so that `react-native-worklets/plugin` works.