### PR TITLE
fix(worklets): regular js functions fails when called

### DIFF
--- a/cpp/wrappers/JsiObjectWrapper.h
+++ b/cpp/wrappers/JsiObjectWrapper.h
@@ -209,12 +209,14 @@ private:
       _hostFunction = std::make_shared<jsi::HostFunctionType>(
           func.getHostFunction(runtime));
     } else {
-
-      throw jsi::JSError(
-          runtime,
-          "Regular javascript functions cannot be shared. Try "
-          "decorating the function with the 'worklet' keyword to allow "
-          "the javascript function to be used as a worklet.");
+      _hostFunction =
+          std::make_shared<jsi::HostFunctionType>(JSI_HOST_FUNCTION_LAMBDA {
+            throw jsi::JSError(
+                runtime,
+                "Regular javascript functions cannot be shared. Try "
+                "decorating the function with the 'worklet' keyword to allow "
+                "the javascript function to be used as a worklet.");
+          });
     }
   }
 

--- a/example/Tests/utils.ts
+++ b/example/Tests/utils.ts
@@ -47,7 +47,7 @@ export const ExpectValue = <V, T>(value: V | Promise<V>, expected: T) => {
 
 export const ExpectException = <T>(
   executor: (() => T) | (() => Promise<T>),
-  expectedReason: string
+  expectedReason?: string
 ) => {
   return new Promise<void>(async (resolve, reject) => {
     try {
@@ -59,16 +59,20 @@ export const ExpectException = <T>(
         reject(new Error("Expected error but function succeeded."));
       }
     } catch (reason: any) {
-      const resolvedReason =
-        typeof reason === "object" ? reason.message : reason;
-      if (resolvedReason === expectedReason) {
-        resolve();
+      if (expectedReason) {
+        const resolvedReason =
+          typeof reason === "object" ? reason.message : reason;
+        if (resolvedReason === expectedReason) {
+          resolve();
+        } else {
+          const errorMessage = `Expected error message '${expectedReason.substr(
+            0,
+            80
+          )}', got '${resolvedReason.substr(0, 80)}'.`;
+          reject(new Error(errorMessage));
+        }
       } else {
-        const errorMessage = `Expected error message '${expectedReason.substr(
-          0,
-          80
-        )}', got '${resolvedReason.substr(0, 80)}'.`;
-        reject(new Error(errorMessage));
+        resolve();
       }
     }
   });

--- a/example/Tests/worklet-tests.ts
+++ b/example/Tests/worklet-tests.ts
@@ -3,12 +3,10 @@ import { ExpectException, ExpectValue, getWorkletInfo } from "./utils";
 
 export const worklet_tests = {
   check_is_not_worklet: () => {
-    return ExpectException(
-      () =>
-        Worklets.createRunInContextFn((a: number) => {
-          return a * 200;
-        }),
-      "Exception in HostFunction: createRunInContextFn expects a worklet decorated function as its first parameter."
+    return ExpectException(() =>
+      Worklets.createRunInContextFn((a: number) => {
+        return a * 200;
+      })
     );
   },
   check_worklet_closure: () => {
@@ -36,5 +34,16 @@ export const worklet_tests = {
     };
     const { code } = getWorkletInfo(w);
     return ExpectValue(code, "function _f(a){return a;}");
+  },
+  check_share_object_with_js_function_fails_on_call: () => {
+    const api = {
+      call: () => 100,
+    };
+    const f = () => {
+      "worklet";
+      return api.call();
+    };
+    const w = Worklets.createRunInContextFn(f);
+    return ExpectException(w);
   },
 };

--- a/ios/Worklets.mm
+++ b/ios/Worklets.mm
@@ -59,7 +59,7 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(install) {
       (facebook::jsi::Runtime *)cxxBridge.runtime;
 
   installApi(callInvoker, jsRuntime);
-  
+
   return std::make_shared<facebook::react::NativeWorkletsSpecJSI>(params);
 }
 #endif


### PR DESCRIPTION
Instead of failing when converted, regular js functions now fails when they are called.

Added test.