### PR TITLE
fix: computed properties are not added to closure

### DIFF
--- a/src/plugin/index.js
+++ b/src/plugin/index.js
@@ -75,7 +75,8 @@ function processWorkletFunction(t, fun, state) {
 
       if (
         parentNode.type === "MemberExpression" &&
-        parentNode.object !== path.node
+        parentNode.object !== path.node &&
+        !parentNode.computed
       ) {
         return;
       }


### PR DESCRIPTION
If a variable is used as a computed property in a worklet it currently doesn't get captured and cause a crash.

For example this doesn't work:

```js
  const value = 'a';

  const worklet = () => {
    'worklet';

    const someObj = {};
    someObj[value] = 1;
  };
  Worklets.createRunInContextFn(worklet)();
```

The fix is based on what is done in the reanimated plugin.