### PR TITLE
feature(worklet): pass worklet args directly

### DIFF
--- a/cpp/JsiWorkletApi.h
+++ b/cpp/JsiWorkletApi.h
@@ -325,7 +325,20 @@ public:
 
                   // Prepare result
                   try {
-                    auto retVal = worklet->call(*workletRuntime, argsWrapper);
+                    // Create arguments
+                    size_t size = argsWrapper.size();
+                    std::vector<jsi::Value> args(size);
+
+                    // Add the rest of the arguments
+                    for (size_t i = 0; i < size; i++) {
+                      args[i] = JsiWrapper::unwrap(*workletRuntime,
+                                                   argsWrapper.at(i));
+                    }
+
+                    auto retVal = worklet->call(
+                        *workletRuntime,
+                        static_cast<const jsi::Value *>(args.data()),
+                        argsWrapper.size());
 
                     // Since we are returning this on another context, we need
                     // to wrap/unwrap the value

--- a/cpp/wrappers/JsiObjectWrapper.h
+++ b/cpp/wrappers/JsiObjectWrapper.h
@@ -191,9 +191,9 @@ private:
   }
 
   void setFunctionValue(jsi::Runtime &runtime, const jsi::Value &value) {
+    setType(JsiWrapperType::HostFunction);
     // Check if the function is decorated as a worklet
     if (JsiWorklet::isDecoratedAsWorklet(runtime, value)) {
-      setType(JsiWrapperType::HostFunction);
       // Create worklet
       auto worklet = std::make_shared<JsiWorklet>(runtime, value);
       // Create wrapping host function
@@ -205,10 +205,13 @@ private:
     }
     auto func = value.asObject(runtime).asFunction(runtime);
     if (func.isHostFunction(runtime)) {
-      setType(JsiWrapperType::HostFunction);
+      // Host functions should just be called
       _hostFunction = std::make_shared<jsi::HostFunctionType>(
           func.getHostFunction(runtime));
     } else {
+      // Create a host function throwing an the error when the
+      // function is called - not when it is created. This way
+      // we can accept any function as long as it is not used.
       _hostFunction =
           std::make_shared<jsi::HostFunctionType>(JSI_HOST_FUNCTION_LAMBDA {
             throw jsi::JSError(

--- a/example/Tests/worklet-context-tests.ts
+++ b/example/Tests/worklet-context-tests.ts
@@ -197,4 +197,25 @@ export const worklet_context_tests = {
     });
     return ExpectException(workletA, "Test error");
   },
+
+  call_worklet_to_worklet_without_wrapping_args: () => {
+    const workletB = (a: { current: number }) => {
+      "worklet";
+      return a.current;
+    };
+    const workletA = Worklets.createRunInContextFn(function () {
+      "worklet";
+      return workletB({ current: 100 });
+    });
+    return ExpectValue(workletA(), 100);
+  },
+
+  fail_when_calling_a_regular_function_from_a_worklet: () => {
+    const func = (a: number) => a;
+    const worklet = Worklets.createRunInContextFn(function () {
+      "worklet";
+      return func(100);
+    });
+    return ExpectException(worklet);
+  },
 };


### PR DESCRIPTION
When calling a worklet on the same runtime we should just pass arguments directly instead of wrapping / unwrapping them.

Closes #16 