### PR TITLE
#19: feature(api): changed api for decorators

### DIFF
--- a/cpp/JsiWorkletContext.cpp
+++ b/cpp/JsiWorkletContext.cpp
@@ -1,0 +1,137 @@
+
+#include "JsiWorkletContext.h"
+
+#include "DispatchQueue.h"
+#include "JsRuntimeFactory.h"
+#include "JsiHostObject.h"
+
+#include <exception>
+#include <functional>
+#include <memory>
+
+#include <jsi/jsi.h>
+
+namespace RNWorklet {
+
+const char *WorkletRuntimeFlag = "__rn_worklets_runtime_flag";
+std::vector<std::shared_ptr<JsiBaseDecorator>> JsiWorkletContext::_decorators;
+
+namespace jsi = facebook::jsi;
+
+JsiWorkletContext::JsiWorkletContext(const std::string &name) {
+  // Create queue
+  auto dispatchQueue =
+      std::make_shared<DispatchQueue>(name + "_worklet_dispatch_queue", 1);
+
+  // Initialize context
+  initialize(name, JsiWorkletContext::getInstance()->_jsRuntime,
+             JsiWorkletContext::getInstance()->_jsCallInvoker,
+             [dispatchQueue](std::function<void()> &&f) {
+               dispatchQueue->dispatch(std::move(f));
+             });
+};
+
+JsiWorkletContext::JsiWorkletContext(
+    const std::string &name,
+    std::function<void(std::function<void()> &&)> workletCallInvoker) {
+  // Initialize context
+  initialize(name, JsiWorkletContext::getInstance()->_jsRuntime,
+             JsiWorkletContext::getInstance()->_jsCallInvoker,
+             workletCallInvoker);
+};
+
+void JsiWorkletContext::initialize(
+    const std::string &name, jsi::Runtime *jsRuntime,
+    std::function<void(std::function<void()> &&)> jsCallInvoker,
+    std::function<void(std::function<void()> &&)> workletCallInvoker) {
+  _name = name;
+  _jsRuntime = jsRuntime;
+  _jsCallInvoker = jsCallInvoker;
+  _workletCallInvoker = workletCallInvoker;
+
+  // Run decorators if we're not the singleton main context
+  if (JsiWorkletContext::getInstance().get() != this) {
+    applyDecorators(_decorators);
+  }
+}
+
+void JsiWorkletContext::initialize(
+    const std::string &name, jsi::Runtime *jsRuntime,
+    std::function<void(std::function<void()> &&)> jsCallInvoker) {
+  // Create queue
+  auto dispatchQueue =
+      std::make_shared<DispatchQueue>(name + "_worklet_dispatch_queue", 1);
+
+  // Initialize invoker
+  initialize(name, jsRuntime, jsCallInvoker,
+             [dispatchQueue](std::function<void()> &&f) {
+               dispatchQueue->dispatch(std::move(f));
+             });
+}
+
+jsi::Runtime &JsiWorkletContext::getWorkletRuntime() {
+  if (!_workletRuntime) {
+    _workletRuntime = makeJSIRuntime();
+    _workletRuntime->global().setProperty(*_workletRuntime, WorkletRuntimeFlag,
+                                          true);
+  }
+
+  return *_workletRuntime;
+}
+
+void JsiWorkletContext::invokeOnJsThread(std::function<void()> &&fp) {
+  if (_jsCallInvoker == nullptr) {
+    throw std::runtime_error(
+        "Expected Worklet context to have a JS call invoker.");
+  }
+  _jsCallInvoker(std::move(fp));
+}
+
+void JsiWorkletContext::invokeOnWorkletThread(std::function<void()> &&fp) {
+  if (_workletCallInvoker == nullptr) {
+    throw std::runtime_error(
+        "Expected Worklet context to have a worklet call invoker.");
+  }
+  _workletCallInvoker(std::move(fp));
+}
+
+bool JsiWorkletContext::isWorkletRuntime(jsi::Runtime &runtime) {
+  auto isWorkletRuntime =
+      runtime.global().getProperty(runtime, WorkletRuntimeFlag);
+  return isWorkletRuntime.isBool() && isWorkletRuntime.getBool();
+}
+
+void JsiWorkletContext::addDecorator(
+    std::shared_ptr<JsiBaseDecorator> decorator) {
+  _decorators.push_back(decorator);
+  // decorate default context
+  JsiWorkletContext::getInstance()->decorate(decorator);
+}
+
+template <typename... Args> void JsiWorkletContext::decorate(Args &&...args) {
+  std::vector<std::shared_ptr<JsiBaseDecorator>> decorators = {args...};
+  applyDecorators(decorators);
+}
+
+void JsiWorkletContext::applyDecorators(
+    const std::vector<std::shared_ptr<JsiBaseDecorator>> &decorators) {
+  std::mutex mu;
+  std::condition_variable cond;
+  bool isFinished = false;
+  std::unique_lock<std::mutex> lock(mu);
+
+  // Execute decoration in context' worklet thread/runtime
+  _workletCallInvoker([&]() {
+    std::lock_guard<std::mutex> lock(mu);
+    for (size_t i = 0; i < decorators.size(); ++i) {
+      decorators[i]->decorateRuntime(getWorkletRuntime());
+    }
+    isFinished = true;
+    cond.notify_one();
+  });
+
+  // Wait untill the blocking code as finished
+  cond.wait(lock, [&]() { return isFinished; });
+}
+
+} // namespace RNWorklet

--- a/cpp/JsiWorkletContext.h
+++ b/cpp/JsiWorkletContext.h
@@ -2,7 +2,6 @@
 #pragma once
 
 #include "DispatchQueue.h"
-#include "JsRuntimeFactory.h"
 #include "JsiBaseDecorator.h"
 #include "JsiHostObject.h"
 
@@ -14,63 +13,66 @@
 
 namespace RNWorklet {
 
-const char *WorkletRuntimeFlag = "__rn_worklets_runtime_flag";
-
 namespace jsi = facebook::jsi;
 
 class JsiWorkletContext : public JsiHostObject {
 public:
   /**
    * Creates a new worklet context that can be used to run javascript functions
-   * as worklets in a separate threads / js runtimes.
+   * as worklets in a separate threads / js runtimes. After construction the
+   * context needs to be initialized.
+   */
+  explicit JsiWorkletContext(){};
+
+  /**
+   Constructs a new worklet context using the same values and configuration as
+   the default context. No need to run initialize on the runtime. The only thing
+   not copied from the default context is the worklet invoker which will be a
+   default queue.
+   @param name Name of the context
+   */
+  JsiWorkletContext(const std::string &name);
+
+  /**
+   Constructs a new worklet context using the same values and configuration as
+   the default context. No need to run initialize on the runtime.
+   @param name Name of the context
+   @param workletCallInvoker Callback for running a function on the worklet
+   thread
+   */
+  JsiWorkletContext(
+      const std::string &name,
+      std::function<void(std::function<void()> &&)> workletCallInvoker);
+
+  /**
+   * Initialializes the worklet context
    * @param name Name of the context
    * @param jsRuntime Main javascript runtime.
    * @param jsCallInvoker Callback for running a function on the JS thread.
    * @param workletCallInvoker Callback for running a function on the worklet
    * thread
    */
-  JsiWorkletContext(
-      const std::string &name, jsi::Runtime *jsRuntime,
-      std::function<void(std::function<void()> &&)> jsCallInvoker,
-      std::function<void(std::function<void()> &&)> workletCallInvoker)
-      : _name(name), _jsRuntime(jsRuntime), _jsCallInvoker(jsCallInvoker),
-        _workletCallInvoker(workletCallInvoker) {}
+  void
+  initialize(const std::string &name, jsi::Runtime *jsRuntime,
+             std::function<void(std::function<void()> &&)> jsCallInvoker,
+             std::function<void(std::function<void()> &&)> workletCallInvoker);
 
   /**
-   * Ctor for the JsiWorkletContext
+   * Initialializes the worklet context
    * @param name Name of the context
    * @param jsRuntime Runtime for the main javascript runtime.
    * @param jsCallInvoker Callback for running a function on the JS thread.
    */
-  JsiWorkletContext(const std::string &name, jsi::Runtime *jsRuntime,
-                    std::function<void(std::function<void()> &&)> jsCallInvoker)
-      : _name(name), _jsRuntime(jsRuntime), _jsCallInvoker(jsCallInvoker) {
-    // Create queue
-    auto dispatchQueue =
-        std::make_shared<DispatchQueue>(name + "_worklet_dispatch_queue", 1);
+  void initialize(const std::string &name, jsi::Runtime *jsRuntime,
+                  std::function<void(std::function<void()> &&)> jsCallInvoker);
 
-    // Create invoker
-    _workletCallInvoker = [dispatchQueue](std::function<void()> &&f) {
-      dispatchQueue->dispatch(std::move(f));
-    };
+  /**
+   Static / singleton default context
+   */
+  static std::shared_ptr<JsiWorkletContext> getInstance() {
+    static auto instance = std::make_shared<JsiWorkletContext>();
+    return instance;
   }
-
-  /**
-   * Creates a new worklet context from a parent context. The new worklet
-   * context will inherit from the parent context, but will create its own
-   * worklet runtime and worklet executor thread.
-   * @param name Name of the context
-   * @param parentContext parent worklet context
-   */
-  JsiWorkletContext(const std::string &name,
-                    std::shared_ptr<JsiWorkletContext> parentContext)
-      : JsiWorkletContext(name, parentContext->_jsRuntime,
-                          parentContext->_jsCallInvoker) {}
-
-  /**
-   * Destructor
-   */
-  virtual ~JsiWorkletContext() {}
 
   JSI_PROPERTY_GET(name) {
     return jsi::String::createFromUtf8(runtime, getName());
@@ -91,54 +93,52 @@ public:
   /**
    Returns the worklet runtime. Lazy evaluated
    */
-  jsi::Runtime &getWorkletRuntime() {
-    if (!_workletRuntime) {
-      _workletRuntime = makeJSIRuntime();
-      _workletRuntime->global().setProperty(*_workletRuntime,
-                                            WorkletRuntimeFlag, true);
-    }
-
-    return *_workletRuntime;
-  }
+  jsi::Runtime &getWorkletRuntime();
 
   /**
    Executes a function in the JS thread
    */
-  void invokeOnJsThread(std::function<void()> &&fp) {
-    if (_jsCallInvoker == nullptr) {
-      throw std::runtime_error(
-          "Expected Worklet context to have a JS call invoker.");
-    }
-    _jsCallInvoker(std::move(fp));
-  }
+  void invokeOnJsThread(std::function<void()> &&fp);
 
   /**
    Executes a function in the worklet thread
    */
-  void invokeOnWorkletThread(std::function<void()> &&fp) {
-    if (_workletCallInvoker == nullptr) {
-      throw std::runtime_error(
-          "Expected Worklet context to have a worklet call invoker.");
-    }
-    _workletCallInvoker(std::move(fp));
-  }
+  void invokeOnWorkletThread(std::function<void()> &&fp);
 
   /**
    * Returns true if the runtime provided is the worklet runtime
    * @param runtime Runtime to check
    * @return True if the runtime is the worklet runtime
    */
-  bool isWorkletRuntime(jsi::Runtime &runtime) {
-    auto isWorklet = runtime.global().getProperty(runtime, WorkletRuntimeFlag);
-    return isWorklet.isBool() && isWorklet.getBool();
+  bool isWorkletRuntime(jsi::Runtime &runtime);
+
+  /**
+   Returns the list of decorators
+   */
+  static const std::vector<std::shared_ptr<JsiBaseDecorator>> &getDecorators() {
+    return _decorators;
   }
 
   /**
-   Decorates the worklet runtime.
+   Adds a global decorator. The decorator will be installed in the default
+   context.
    */
-  void decorate(JsiBaseDecorator *decorator) {
-    decorator->decorateRuntime(getWorkletRuntime());
-  }
+  static void addDecorator(std::shared_ptr<JsiBaseDecorator> decorator);
+
+  /**
+   Decorates the worklet runtime. The decorator is run in the worklet runtime
+   and on the worklet thread, since it is not legal to access the worklet
+   runtime from the javascript thread.
+   */
+  template <typename... Args> void decorate(Args &&...args);
+
+  /**
+   Decorates the worklet runtime. The decorator is run in the worklet runtime
+   and on the worklet thread, since it is not legal to access the worklet
+   runtime from the javascript thread.
+   */
+  void applyDecorators(
+      const std::vector<std::shared_ptr<JsiBaseDecorator>> &decorators);
 
 private:
   jsi::Runtime *_jsRuntime;
@@ -146,6 +146,8 @@ private:
   std::string _name;
   std::function<void(std::function<void()> &&)> _jsCallInvoker;
   std::function<void(std::function<void()> &&)> _workletCallInvoker;
+
+  static std::vector<std::shared_ptr<JsiBaseDecorator>> _decorators;
 };
 
 } // namespace RNWorklet

--- a/cpp/dispatch/DispatchQueue.h
+++ b/cpp/dispatch/DispatchQueue.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <condition_variable>
 #include <cstdint>
 #include <cstdio>

--- a/ios/Worklets.mm
+++ b/ios/Worklets.mm
@@ -25,14 +25,14 @@ RCT_EXPORT_MODULE()
 
 void installApi(std::shared_ptr<facebook::react::CallInvoker> callInvoker,
                 facebook::jsi::Runtime *runtime) {
-  // Create the worklet context
-  auto workletContext = std::make_shared<RNWorklet::JsiWorkletContext>(
+  // Initialize the default worklet context
+  RNWorklet::JsiWorkletContext::getInstance()->initialize(
       "default", runtime, [=](std::function<void()> &&f) {
         callInvoker->invokeAsync(std::move(f));
       });
 
   // Install the worklet API
-  RNWorklet::JsiWorkletApi::installApi(workletContext);
+  RNWorklet::JsiWorkletApi::installApi();
 }
 
 RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(install) {


### PR DESCRIPTION
Previously the worklet context decorator API was a bit misleading since you had to call it through the Worklet API for everything to be installed correctly.

With this change the default worklet context is a singleton that can be accessed with JsiWorkletContext::getInstance(). The list of decorators are also static and global for all worklet contexts.

Decorators are also decorated in the worklet context thread / runtime.

fixes #19