### PR TITLE
feat: sync up plugin with reanimated implementation

### DIFF
--- a/src/plugin/__tests__/index.spec.ts
+++ b/src/plugin/__tests__/index.spec.ts
@@ -2,7 +2,7 @@ const { transform } = require("@babel/core");
 const prettier = require("prettier");
 
 const conf = {
-  filename: "test.js",
+  filename: "test.ts",
 };
 
 describe("babel-plugin-preserve-jscontext-function-to-string", () => {
@@ -17,7 +17,7 @@ describe("babel-plugin-preserve-jscontext-function-to-string", () => {
     const f = runPluginAndEval('function run() {"worklet"; return 1000;}');
     expect(f._closure).toEqual({});
     expect(f.asString).toEqual("function run(){return 1000;}");
-    expect(f.__location).toContain("test.js (1:0)");
+    expect(f.__location).toContain("test.ts (1:0)");
   });
 
   it("should work with typescript types", () => {
@@ -39,7 +39,7 @@ describe("babel-plugin-preserve-jscontext-function-to-string", () => {
         }
       };`
     );
-    expect(output).toContain(`_run.asString = "function run(){this.stop();}"`);
+    expect(output).toContain(`_f.asString = "function run(){this.stop();}"`);
   });
 
   it("should redeclare code with dependencies", () => {
@@ -112,7 +112,7 @@ describe("babel-plugin-preserve-jscontext-function-to-string", () => {
     const [, output] = transformCode(`useWorklet(() => 1);`, undefined, {
       functionsToWorkletize: [{ name: "useWorklet", args: [0] }],
     });
-    expect(output).toContain(`__f.asString = "function _f(){return 1;}"`);
+    expect(output).toContain(`_f.asString = "function anonymous(){return 1;}"`);
   });
 });
 


### PR DESCRIPTION
Fixes #15

I ended up rewriting the plugin starting from the current reanimated implmentation. This is basically a simplified version. Their runtime currently handles a few more things than we do, so I removed support from it as it is kind of out of scope if this issue and we can re-add support for it later if we want.

Differences from reanimated plugin:

- Handle globals via `global.hasOwnProperty` instead of hardcoded list
- Support for `functionsToWorkletize` plugin option
- Removed source maps support, needs runtime support
- Removed `blacklistedFunctions` / `ClosureGenerator`,  not sure exactly what does are for, but they caused issues
- Removed any reanimated / gesture handler specific code
- Removed recursive function support (`_recur`), needs runtime support
- Removed `__workletHash` and `__optimalization`
- Use `jsThis` instead of `this._closure`