### PR TITLE
feature(wrappers): added proxy support

### DIFF
--- a/cpp/wrappers/JsiObjectWrapper.h
+++ b/cpp/wrappers/JsiObjectWrapper.h
@@ -10,6 +10,8 @@ namespace RNWorklet {
 
 namespace jsi = facebook::jsi;
 
+const char *WorkletObjectProxyName = "__createWorkletObjectProxy";
+
 class JsiObjectWrapper : public JsiHostObject,
                          public std::enable_shared_from_this<JsiObjectWrapper>,
                          public JsiWrapper {
@@ -25,28 +27,10 @@ public:
                    JsiWrapper *parent)
       : JsiWrapper(runtime, value, parent) {}
 
-  JSI_PROPERTY_GET(__proto__) {
-    // Update prototype
-    auto objectCtor = runtime.global().getProperty(runtime, "Object");
-    if (!objectCtor.isUndefined()) {
-      // Get setPrototypeOf
-      auto setPrototypeOf =
-          objectCtor.asObject(runtime).getProperty(runtime, "setPrototypeOf");
-      if (!setPrototypeOf.isUndefined()) {
-        auto object = runtime.global().getProperty(runtime, "Object");
-        if (!object.isUndefined()) {
-          return object.asObject(runtime).getProperty(runtime, "prototype");
-        }
-      }
-    }
-    return jsi::Value::undefined();
-  }
-
   JSI_HOST_FUNCTION(toStringImpl) {
     return jsi::String::createFromUtf8(runtime, toString(runtime));
   }
 
-  JSI_EXPORT_PROPERTY_GETTERS(JSI_EXPORT_PROP_GET(JsiObjectWrapper, __proto__))
   JSI_EXPORT_FUNCTIONS(JSI_EXPORT_FUNC_NAMED(JsiObjectWrapper, toStringImpl,
                                              toString),
                        JSI_EXPORT_FUNC_NAMED(JsiObjectWrapper, toStringImpl,
@@ -86,13 +70,13 @@ public:
   jsi::Value getValue(jsi::Runtime &runtime) override {
     switch (getType()) {
     case JsiWrapperType::HostObject:
-      return jsi::Object::createFromHostObject(runtime, _hostObject);
+      return getObjectProxy(runtime, _hostObject);
     case JsiWrapperType::HostFunction:
       return jsi::Function::createFromHostFunction(
           runtime, jsi::PropNameID::forUtf8(runtime, "fn"), 0,
           *_hostFunction.get());
     case JsiWrapperType::Object:
-      return jsi::Object::createFromHostObject(runtime, shared_from_this());
+      return getObjectProxy(runtime, shared_from_this());
     case JsiWrapperType::Promise:
       throw jsi::JSError(runtime, "Promise type not supported.");
     default:
@@ -159,7 +143,7 @@ public:
     case JsiWrapperType::HostFunction:
       return "[Function hostFunction]";
     case JsiWrapperType::Object:
-      return "[Object object]";
+      return "[object Object]";
     default:
       throw jsi::JSError(runtime, "Value type not supported.");
       return "[unsupported]";
@@ -167,6 +151,43 @@ public:
   }
 
 private:
+  /**
+   Creates a proxy for the host object so that we can make the runtime trust
+   that this is a real JS object
+   */
+  jsi::Value getObjectProxy(jsi::Runtime &runtime,
+                            std::shared_ptr<jsi::HostObject> hostObj) {
+
+    auto createObjProxy =
+        runtime.global().getProperty(runtime, WorkletObjectProxyName);
+    if (createObjProxy.isUndefined()) {
+      // Install worklet proxy helper into runtime
+      static std::string code =
+          "function (obj) {"
+          "  return new Proxy(obj, {"
+          "    getOwnPropertyDescriptor: function () {"
+          "      return { configurable: true, enumerable: true, writable: true "
+          "};"
+          "    },"
+          " set: function(target, prop, value) { return Reflect.set(target, "
+          "prop, value); },"
+          " get: function(target, prop) { return Reflect.get(target, prop); }"
+          "  });"
+          "}";
+
+      auto codeBuffer =
+          std::make_shared<const jsi::StringBuffer>("(" + code + "\n)");
+      createObjProxy =
+          runtime.evaluateJavaScript(codeBuffer, WorkletObjectProxyName);
+      runtime.global().setProperty(runtime, WorkletObjectProxyName,
+                                   createObjProxy);
+    }
+
+    auto createProxyFunc = createObjProxy.asObject(runtime).asFunction(runtime);
+    return createProxyFunc.call(
+        runtime, jsi::Object::createFromHostObject(runtime, hostObj));
+  }
+
   void setArrayBufferValue(jsi::Runtime &runtime, jsi::Object &obj) {
     throw jsi::JSError(runtime,
                        "Array buffers are not supported as shared values.");

--- a/example/Tests/sharedvalue-tests.ts
+++ b/example/Tests/sharedvalue-tests.ts
@@ -39,6 +39,21 @@ export const sharedvalue_tests = {
     );
   },
 
+  is_object: () => {
+    const sharedValue = Worklets.createSharedValue({ a: 100, b: 200 });
+    return ExpectValue(typeof sharedValue.value === "object", true);
+  },
+
+  object_keys: () => {
+    const sharedValue = Worklets.createSharedValue({ a: 100, b: 200 });
+    return ExpectValue(Object.keys(sharedValue.value), ["a", "b"]);
+  },
+
+  object_values: () => {
+    const sharedValue = Worklets.createSharedValue({ a: 100, b: 200 });
+    return ExpectValue(Object.values(sharedValue.value), [100, 200]);
+  },
+
   box_number_to_string: () => {
     const sharedValue = Worklets.createSharedValue(100);
     // @ts-ignore
@@ -81,6 +96,20 @@ export const sharedvalue_tests = {
     return ExpectValue(sharedValue.value, [100.34, 200]);
   },
 
+  array_object_keys: () => {
+    return ExpectValue(
+      Object.keys(Worklets.createSharedValue([50, 21, 32]).value),
+      ["0", "1", "2"]
+    );
+  },
+
+  array_object_values: () => {
+    return ExpectValue(
+      Object.values(Worklets.createSharedValue([50, 21, 32]).value),
+      [50, 21, 32]
+    );
+  },
+
   array_spread: () => {
     const sharedValue = Worklets.createSharedValue([100, 200]);
     const p = [...sharedValue.value];
@@ -107,7 +136,7 @@ export const sharedvalue_tests = {
   object_value_destructure: () => {
     const sharedValue = Worklets.createSharedValue({ a: 100, b: 200 });
     const { a, b } = { ...sharedValue.value };
-    return ExpectValue({ a, b }, { a: 100, b: 100 });
+    return ExpectValue({ a, b }, { a: 100, b: 200 });
   },
 
   object_value_spread: () => {
@@ -130,10 +159,10 @@ export const sharedvalue_tests = {
     );
   },
 
-  set_function_with_error: () => {
+  set_function_fails_when_calling_function: () => {
     return ExpectException(() => {
-      Worklets.createSharedValue(() => {});
-    }, "Regular javascript functions cannot be shared.");
+      Worklets.createSharedValue(() => {}).value();
+    });
   },
 
   add_listener: () => {

--- a/example/Tests/wrapper-tests.ts
+++ b/example/Tests/wrapper-tests.ts
@@ -1,10 +1,13 @@
 import { Worklets } from "react-native-worklets";
-import { ExpectException, ExpectValue } from "./utils";
+import { ExpectValue } from "./utils";
 
 const convert =
   <T>(value: T): (() => Promise<void>) =>
-  () =>
-    ExpectValue(Worklets.createSharedValue(value).value, value);
+  () => {
+    const a = Worklets.createSharedValue(value).value;
+    const b = value;
+    return ExpectValue(a, b);
+  };
 
 export const wrapper_tests = {
   convert_undefined: convert(undefined),
@@ -22,18 +25,16 @@ export const wrapper_tests = {
       { x: 5, y: 23 },
     ],
   }),
-  convert_function_throws_exception: () => {
-    return ExpectException(() => {
-      return Promise.resolve(Worklets.createSharedValue(() => {}));
-    }, "Regular javascript functions cannot be shared.");
-  },
 
   array_is_array: () => {
     return ExpectValue(Array.isArray(Worklets.createSharedValue([])), true);
   },
 
   array_instanceof_array: () => {
-    return ExpectValue(Worklets.createSharedValue([]) instanceof Array, true);
+    return ExpectValue(
+      Worklets.createSharedValue([]).value instanceof Array,
+      true
+    );
   },
 
   array_get: () => ExpectValue(Worklets.createSharedValue([100]).value[0], 100),
@@ -177,10 +178,7 @@ export const wrapper_tests = {
     const array = Worklets.createSharedValue([100, 200]);
     return ExpectValue(
       array.value.reduce((acc, cur, index) => {
-        console.log("before", acc, index, cur);
-        console.log({ ...acc });
         const retVal = { ...acc, [index]: cur };
-        console.log("after", retVal);
         return retVal;
       }, {}),
       { 0: 100, 1: 200 }


### PR DESCRIPTION
To make sure our objects and array behaves and looks like their js twins, we now wrap them in proxies. This fixes a lot of the tests and objects are now 100% compatible, while arrays are like 90% (Array.isArray is not working, but instanceof Array is.)

Updated tests.

Fixes #18 (maybe?)
Closes #17