### PR TITLE
fix(context): stop copying worklets in closures

### DIFF
--- a/cpp/JsiWorkletApi.cpp
+++ b/cpp/JsiWorkletApi.cpp
@@ -1,0 +1,59 @@
+#include "JsiWorkletApi.h"
+
+#include <jsi/jsi.h>
+
+#include <vector>
+
+#include "JsiBaseDecorator.h"
+#include "JsiHostObject.h"
+#include "JsiJsDecorator.h"
+#include "JsiPromise.h"
+#include "JsiSharedValue.h"
+#include "JsiWorklet.h"
+#include "JsiWorkletContext.h"
+
+namespace RNWorklet {
+
+namespace jsi = facebook::jsi;
+
+const char *JsiWorkletApi::WorkletsApiName = "Worklets";
+std::shared_ptr<JsiWorkletApi> JsiWorkletApi::instance;
+
+/**
+ * Installs the worklet API into the provided runtime
+ */
+void JsiWorkletApi::installApi(jsi::Runtime &runtime) {
+  auto context = JsiWorkletContext::getInstance();
+  auto existingApi = (runtime.global().getProperty(runtime, WorkletsApiName));
+  if (existingApi.isObject()) {
+    return;
+  }
+
+  runtime.global().setProperty(
+      runtime, WorkletsApiName,
+      jsi::Object::createFromHostObject(runtime, getInstance()));
+}
+
+std::shared_ptr<JsiWorkletContext>
+JsiWorkletApi::createWorkletContext(const std::string &name) {
+  return std::make_shared<JsiWorkletContext>(name);
+}
+
+void JsiWorkletApi::addDecorator(std::shared_ptr<JsiBaseDecorator> decorator) {
+  // Decorate default context
+  JsiWorkletContext::addDecorator(decorator);
+}
+
+std::shared_ptr<JsiWorkletApi> JsiWorkletApi::getInstance() {
+  if (instance == nullptr) {
+    instance = std::make_shared<JsiWorkletApi>();
+  }
+  return instance;
+}
+
+/**
+ Invalidate the api instance.
+ */
+void JsiWorkletApi::invalidateInstance() { instance = nullptr; }
+
+} // namespace RNWorklet

--- a/cpp/JsiWorkletContext.cpp
+++ b/cpp/JsiWorkletContext.cpp
@@ -1,5 +1,6 @@
 
 #include "JsiWorkletContext.h"
+#include "JsiWorkletApi.h"
 
 #include "DispatchQueue.h"
 #include "JsRuntimeFactory.h"
@@ -78,6 +79,9 @@ jsi::Runtime &JsiWorkletContext::getWorkletRuntime() {
     // object.
     _workletRuntime->global().setProperty(*_workletRuntime, GlobalPropertyName,
                                           _workletRuntime->global());
+
+    // Install the WorkletAPI into the new runtime
+    JsiWorkletApi::installApi(*_workletRuntime);
 
     // Run decorators if we're not the singleton main context - no need to
     // do this in the worklet thread because we should already be in the

--- a/ios/Worklets.mm
+++ b/ios/Worklets.mm
@@ -13,6 +13,7 @@ RCT_EXPORT_MODULE()
 
 - (void)invalidate {
   RNWorklet::JsiWorkletContext::invalidateInstance();
+  RNWorklet::JsiWorkletApi::invalidateInstance();
   _bridge = nil;
 }
 
@@ -33,7 +34,7 @@ void installApi(std::shared_ptr<facebook::react::CallInvoker> callInvoker,
       });
 
   // Install the worklet API
-  RNWorklet::JsiWorkletApi::installApi();
+  RNWorklet::JsiWorkletApi::installApi(*runtime);
 }
 
 RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(install) {

--- a/src/plugin/index.js
+++ b/src/plugin/index.js
@@ -14,14 +14,19 @@ function buildWorkletString(t, fun, closureVariables, name, inputMap) {
     const closureDeclaration = t.variableDeclaration("const", [
       t.variableDeclarator(
         t.objectPattern(
-          closureVariables.map((variable) =>
-            t.objectProperty(
-              t.identifier(variable.name),
-              t.identifier(variable.name),
-              false,
-              true
+          closureVariables
+            // We shouldn't copy the worklets API to the closure -
+            // it will be installed in each worklet runtime separately.
+            // https://github.com/chrfalch/react-native-worklets/issues/24
+            .filter((v) => v.name !== "Worklets")
+            .map((variable) =>
+              t.objectProperty(
+                t.identifier(variable.name),
+                t.identifier(variable.name),
+                false,
+                true
+              )
             )
-          )
         ),
         t.identifier("jsThis")
       ),


### PR DESCRIPTION
We should avoid adding the Worklets API to the closure, since we can install it manually whenever we create a new worklet context.

This fixes this by:
- Adding an instance/singleton field to the WorkletAPI
- Adding invalidation of the singleton on module invalidation
- Added test to stop copying the worklet api to the closure in the plugin
- Added installing the worklets api into new worklet runtimes.

Fixes #24 