### PR TITLE
fix: add `string-hash-64` to `dependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,6 @@
     "react-native": "0.71.2",
     "react-native-builder-bob": "^0.20.0",
     "release-it": "^15.0.0",
-    "string-hash-64": "^1.0.3",
     "typescript": "^4.5.2"
   },
   "resolutions": {
@@ -187,5 +186,8 @@
     "android": {
       "javaPackageName": "com.worklets"
     }
+  },
+  "dependencies": {
+    "string-hash-64": "^1.0.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8897,16 +8897,17 @@ statuses@~1.5.0:
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
   integrity sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==
 
-string-hash-64@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/string-hash-64/-/string-hash-64-1.0.3.tgz#0deb56df58678640db5c479ccbbb597aaa0de322"
-  integrity sha512-D5OKWKvDhyVWWn2x5Y9b+37NUllks34q1dCDhk/vYcso9fmhs+Tl3KR/gE4v5UNj2UA35cnX4KdVVGkG1deKqw==
 stop-iteration-iterator@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/stop-iteration-iterator/-/stop-iteration-iterator-1.0.0.tgz#6a60be0b4ee757d1ed5254858ec66b10c49285e4"
   integrity sha512-iCGQj+0l0HOdZ2AEeBADlsRC+vsnDsZsbdSiH1yNSjcfKM7fdpCMfqAL/dwF5BLiw/XhRft/Wax6zQbhq2BcjQ==
   dependencies:
     internal-slot "^1.0.4"
+
+string-hash-64@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/string-hash-64/-/string-hash-64-1.0.3.tgz#0deb56df58678640db5c479ccbbb597aaa0de322"
+  integrity sha512-D5OKWKvDhyVWWn2x5Y9b+37NUllks34q1dCDhk/vYcso9fmhs+Tl3KR/gE4v5UNj2UA35cnX4KdVVGkG1deKqw==
 
 string-length@^4.0.1:
   version "4.0.2"


### PR DESCRIPTION
Previously `string-hash-64` was added to `devDependencies`, which is only part of the RN Worklets project. For it to be also part of the user's app, we need to add it to `dependencies` here as we need `string-hash-64` to run on Metro build.

When I tried to run my app previously, metro complained about not finding `string-hash-64`. After adding it to dependencies it works - but I think without tree shaking this would make it into the end user's bundle, right? So not sure if this is the optimal solution