### PR TITLE
fix: Use correct jsc lib import when hermes is disabled

### DIFF
--- a/cpp/WKTJsRuntimeFactory.h
+++ b/cpp/WKTJsRuntimeFactory.h
@@ -10,9 +10,11 @@
 #if JS_RUNTIME_HERMES
 // Hermes
 #include <hermes/hermes.h>
+#elif __has_include(<React-jsc/JSCRuntime.h>)
+  // JSC
+  #include <React-jsc/JSCRuntime.h>
 #else
-// JSC
-#include <react-jsc/JSCRuntime.h>
+  #include <jsc/JSCRuntime.h>
 #endif
 
 namespace RNWorklet {

--- a/cpp/WKTJsRuntimeFactory.h
+++ b/cpp/WKTJsRuntimeFactory.h
@@ -12,7 +12,7 @@
 #include <hermes/hermes.h>
 #else
 // JSC
-#include <jsc/JSCRuntime.h>
+#include <react-jsc/JSCRuntime.h>
 #endif
 
 namespace RNWorklet {

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -55,6 +55,12 @@ target 'WorkletsExample' do
       # necessary for Mac Catalyst builds
       :mac_catalyst_enabled => false
     )
+    # NOTE: Change IPHONEOS_DEPLOYMENT_TARGET to 12.4.
+    installer.pods_project.targets.each do |target|
+      target.build_configurations.each do |config|
+        config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '12.4'
+      end
+    end
     __apply_Xcode_12_5_M1_post_install_workaround(installer)
   end
 end

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -4079,6 +4079,11 @@ statuses@~1.5.0:
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
   integrity sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==
 
+string-hash-64@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/string-hash-64/-/string-hash-64-1.0.3.tgz#0deb56df58678640db5c479ccbbb597aaa0de322"
+  integrity sha512-D5OKWKvDhyVWWn2x5Y9b+37NUllks34q1dCDhk/vYcso9fmhs+Tl3KR/gE4v5UNj2UA35cnX4KdVVGkG1deKqw==
+
 string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"


### PR DESCRIPTION
When Hermes is disabled, example app is failing to build on iOS  in `cpp/WKTJsRuntimeFactory.h` line 15 with the following error: `/react-native-worklets-core/cpp/WKTJsRuntimeFactory.h:15:10 'jsc/JSCRuntime.h' file not found.`.

Note that this same issue was resolved in react-native-vision-camera. Issue: https://github.com/mrousavy/react-native-vision-camera/issues/1450. PR: https://github.com/mrousavy/react-native-vision-camera/pull/1456.


<img width="776" alt="image" src="https://github.com/margelo/react-native-worklets-core/assets/46863427/6dd78f10-dc0a-459a-ad6b-45d1f37cd2dc">


Solves: #115