### PR TITLE
fix: Rename `_closure` to `__closure` to fix REA compatibility

### DIFF
--- a/cpp/WKTJsiWorklet.h
+++ b/cpp/WKTJsiWorklet.h
@@ -25,7 +25,7 @@ static const char *PropNameWorkletInitDataSourceMap = "__sourceMap";
 static const char *PropNameWorkletLocation = "__location";
 static const char *PropNameWorkletAsString = "asString";
 
-static const char *PropNameWorkletClosure = "_closure";
+static const char *PropNameWorkletClosure = "__closure";
 static const char *PropFunctionName = "name";
 
 namespace jsi = facebook::jsi;
@@ -198,7 +198,7 @@ public:
                   const jsi::Value *arguments, size_t count) {
 
     // Unwrap closure
-    auto unwrappedClosure = JsiWrapper::unwrap(runtime, _closureWrapper);
+    auto unwrappedClosure = JsiWrapper::unwrap(runtime, __closureWrapper);
 
     if (_isRea30Compat) {
 
@@ -305,7 +305,7 @@ private:
     _isWorklet = true;
 
     // Create closure wrapper so it will be accessible across runtimes
-    _closureWrapper = JsiWrapper::wrap(runtime, closure);
+    __closureWrapper = JsiWrapper::wrap(runtime, closure);
 
     // Try get the name of the function
     auto nameProp = func->getProperty(runtime, PropFunctionName);
@@ -322,7 +322,7 @@ private:
   }
 
   bool _isWorklet = false;
-  std::shared_ptr<JsiWrapper> _closureWrapper;
+  std::shared_ptr<JsiWrapper> __closureWrapper;
   std::string _location = "";
   std::string _code = "";
   std::string _name = "fn";

--- a/cpp/WKTJsiWorklet.h
+++ b/cpp/WKTJsiWorklet.h
@@ -198,7 +198,7 @@ public:
                   const jsi::Value *arguments, size_t count) {
 
     // Unwrap closure
-    auto unwrappedClosure = JsiWrapper::unwrap(runtime, __closureWrapper);
+    auto unwrappedClosure = JsiWrapper::unwrap(runtime, _closureWrapper);
 
     if (_isRea30Compat) {
 
@@ -305,7 +305,7 @@ private:
     _isWorklet = true;
 
     // Create closure wrapper so it will be accessible across runtimes
-    __closureWrapper = JsiWrapper::wrap(runtime, closure);
+    _closureWrapper = JsiWrapper::wrap(runtime, closure);
 
     // Try get the name of the function
     auto nameProp = func->getProperty(runtime, PropFunctionName);
@@ -322,7 +322,7 @@ private:
   }
 
   bool _isWorklet = false;
-  std::shared_ptr<JsiWrapper> __closureWrapper;
+  std::shared_ptr<JsiWrapper> _closureWrapper;
   std::string _location = "";
   std::string _code = "";
   std::string _name = "fn";

--- a/example/Tests/utils.ts
+++ b/example/Tests/utils.ts
@@ -93,7 +93,7 @@ export const getWorkletInfo = <T extends Array<unknown>, R>(
   // @ts-ignore
   return worklet.__initData
     ? // @ts-ignore
-      { closure: worklet._closure, code: worklet.__initData.code }
+      { closure: worklet.__closure, code: worklet.__initData.code }
     : // @ts-ignore
-      { closure: worklet._closure, code: worklet.asString };
+      { closure: worklet.__closure, code: worklet.asString };
 };

--- a/example/Tests/worklet-tests.ts
+++ b/example/Tests/worklet-tests.ts
@@ -8,7 +8,7 @@ export const worklet_tests = {
     });
     return ExpectValue(typeof fn, "function");
   },
-  check_worklet_closure: () => {
+  check_worklet__closure: () => {
     const x = 100;
     const w = (a: number) => {
       "worklet";
@@ -35,7 +35,7 @@ export const worklet_tests = {
     let wf = Worklets.createRunInContextFn(fw);
     return ExpectValue(wf(), 200);
   },
-  check_worklet_closure_shared_value: () => {
+  check_worklet__closure_shared_value: () => {
     const x = Worklets.createSharedValue(1000);
     const w = (a: number) => {
       "worklet";

--- a/example/Tests/worklet-tests.ts
+++ b/example/Tests/worklet-tests.ts
@@ -8,7 +8,7 @@ export const worklet_tests = {
     });
     return ExpectValue(typeof fn, "function");
   },
-  check_worklet__closure: () => {
+  check_worklet_closure: () => {
     const x = 100;
     const w = (a: number) => {
       "worklet";
@@ -35,7 +35,7 @@ export const worklet_tests = {
     let wf = Worklets.createRunInContextFn(fw);
     return ExpectValue(wf(), 200);
   },
-  check_worklet__closure_shared_value: () => {
+  check_worklet_closure_shared_value: () => {
     const x = Worklets.createSharedValue(1000);
     const w = (a: number) => {
       "worklet";

--- a/src/plugin/__tests__/__snapshots__/index.spec.js.snap
+++ b/src/plugin/__tests__/__snapshots__/index.spec.js.snap
@@ -6,7 +6,7 @@ var objX = {
   x: x
 };
 var _worklet_5359970077727_init_data = {
-  code: \\"function f(){const{x,objX}=this._closure;return{res:x+objX.x};}\\",
+  code: \\"function f(){const{x,objX}=this.__closure;return{res:x+objX.x};}\\",
   location: \\"${ process.cwd() }/jest tests fixture\\"
 };
 var f = function () {
@@ -16,7 +16,7 @@ var f = function () {
       res: x + objX.x
     };
   };
-  _f._closure = {
+  _f.__closure = {
     x: x,
     objX: {
       x: objX.x
@@ -39,7 +39,7 @@ var f = function () {
   var _f = function _f() {
     console.log('test');
   };
-  _f._closure = {};
+  _f.__closure = {};
   _f.__initData = _worklet_13298016111221_init_data;
   _f.__workletHash = 13298016111221;
   _f.__stackDetails = _e;
@@ -64,7 +64,7 @@ var foo = function () {
     var bar = 'worklet';
     var baz = \\"worklet\\";
   };
-  _f._closure = {};
+  _f.__closure = {};
   _f.__initData = _worklet_7442778059540_init_data;
   _f.__workletHash = 7442778059540;
   _f.__stackDetails = _e;
@@ -90,7 +90,7 @@ function App() {
     onStart: function () {
       var _e = [new Error(), 1, -20];
       var _f = function _f() {};
-      _f._closure = {};
+      _f.__closure = {};
       _f.__initData = _worklet_4434179069699_init_data;
       _f.__workletHash = 4434179069699;
       _f.__stackDetails = _e;
@@ -110,7 +110,7 @@ function App() {
     onStart: function () {
       var _e = [new Error(), 1, -20];
       var _f = function _f() {};
-      _f._closure = {};
+      _f.__closure = {};
       _f.__initData = _worklet_4434179069699_init_data;
       _f.__workletHash = 4434179069699;
       _f.__stackDetails = _e;
@@ -122,7 +122,7 @@ function App() {
 
 exports[`babel plugin supports SequenceExpression, with worklet closure 1`] = `
 "var _worklet_5237526540557_init_data = {
-  code: \\"function onStart(){const{obj}=this._closure;var a=obj.a;}\\",
+  code: \\"function onStart(){const{obj}=this.__closure;var a=obj.a;}\\",
   location: \\"${ process.cwd() }/jest tests fixture\\"
 };
 function App() {
@@ -136,7 +136,7 @@ function App() {
       var _f = function _f() {
         var a = obj.a;
       };
-      _f._closure = {
+      _f.__closure = {
         obj: {
           a: obj.a
         }
@@ -156,7 +156,7 @@ exports[`babel plugin supports nested worklets keeping worklet decoration for in
   location: \\"${ process.cwd() }/jest tests fixture\\"
 };
 var _worklet_7858844471746_init_data = {
-  code: \\"function anonymous(){const{_worklet_16463389415794_init_data}=this._closure;var b=function(){var _e=[new Error(),1,-20];var _f=function _f(){return 200;};_f._closure={};_f.__initData=_worklet_16463389415794_init_data;_f.__workletHash=16463389415794;_f.__stackDetails=_e;return _f;}();return 100+b();}\\",
+  code: \\"function anonymous(){const{_worklet_16463389415794_init_data}=this.__closure;var b=function(){var _e=[new Error(),1,-20];var _f=function _f(){return 200;};_f.__closure={};_f.__initData=_worklet_16463389415794_init_data;_f.__workletHash=16463389415794;_f.__stackDetails=_e;return _f;}();return 100+b();}\\",
   location: \\"${ process.cwd() }/jest tests fixture\\"
 };
 var f = function () {
@@ -167,7 +167,7 @@ var f = function () {
       var _f = function _f() {
         return 200;
       };
-      _f._closure = {};
+      _f.__closure = {};
       _f.__initData = _worklet_16463389415794_init_data;
       _f.__workletHash = 16463389415794;
       _f.__stackDetails = _e;
@@ -175,7 +175,7 @@ var f = function () {
     }();
     return 100 + b();
   };
-  _f._closure = {
+  _f.__closure = {
     _worklet_16463389415794_init_data: _worklet_16463389415794_init_data
   };
   _f.__initData = _worklet_7858844471746_init_data;
@@ -188,7 +188,7 @@ var f = function () {
 exports[`babel plugin supports recursive calls 1`] = `
 "var a = 1;
 var _worklet_2022702330805_init_data = {
-  code: \\"function foo(t){const foo=this._recur;const{a}=this._closure;if(t>0){return a+foo(t-1);}}\\",
+  code: \\"function foo(t){const foo=this._recur;const{a}=this.__closure;if(t>0){return a+foo(t-1);}}\\",
   location: \\"${ process.cwd() }/jest tests fixture\\"
 };
 var foo = function () {
@@ -198,7 +198,7 @@ var foo = function () {
       return a + foo(t - 1);
     }
   };
-  _f._closure = {
+  _f.__closure = {
     a: a
   };
   _f.__initData = _worklet_2022702330805_init_data;
@@ -246,7 +246,7 @@ var foo = function () {
     var bar = [4, 5];
     var baz = [1].concat([2, 3], bar);
   };
-  _f._closure = {};
+  _f.__closure = {};
   _f.__initData = _worklet_8509370056349_init_data;
   _f.__workletHash = 8509370056349;
   _f.__stackDetails = _e;
@@ -267,7 +267,7 @@ var foo = function () {
     }
     console.log(args);
   };
-  _f._closure = {};
+  _f.__closure = {};
   _f.__initData = _worklet_14198358014380_init_data;
   _f.__workletHash = 14198358014380;
   _f.__stackDetails = _e;
@@ -279,7 +279,7 @@ exports[`babel plugin transforms spread operator in worklets for function calls 
 "var _interopRequireDefault = require(\\"@babel/runtime/helpers/interopRequireDefault\\");
 var _toConsumableArray2 = _interopRequireDefault(require(\\"@babel/runtime/helpers/toConsumableArray\\"));
 var _worklet_4972199179357_init_data = {
-  code: \\"function foo(arg){const{_toConsumableArray}=this._closure;var _console;(_console=console).log.apply(_console,_toConsumableArray(arg));}\\",
+  code: \\"function foo(arg){const{_toConsumableArray}=this.__closure;var _console;(_console=console).log.apply(_console,_toConsumableArray(arg));}\\",
   location: \\"${ process.cwd() }/jest tests fixture\\"
 };
 var foo = function () {
@@ -288,7 +288,7 @@ var foo = function () {
     var _console;
     (_console = console).log.apply(_console, (0, _toConsumableArray2.default)(arg));
   };
-  _f._closure = {
+  _f.__closure = {
     _toConsumableArray: _toConsumableArray2.default
   };
   _f.__initData = _worklet_4972199179357_init_data;
@@ -317,7 +317,7 @@ var foo = function () {
       c: 3
     }, bar);
   };
-  _f._closure = {};
+  _f.__closure = {};
   _f.__initData = _worklet_12506920427210_init_data;
   _f.__workletHash = 12506920427210;
   _f.__stackDetails = _e;
@@ -335,7 +335,7 @@ var foo = function () {
   var _f = function _f(x) {
     return x + 2;
   };
-  _f._closure = {};
+  _f.__closure = {};
   _f.__initData = _worklet_16347365292089_init_data;
   _f.__workletHash = 16347365292089;
   _f.__stackDetails = _e;
@@ -353,7 +353,7 @@ var foo = function () {
   var _f = function _f(x) {
     return x + 2;
   };
-  _f._closure = {};
+  _f.__closure = {};
   _f.__initData = _worklet_4679479961836_init_data;
   _f.__workletHash = 4679479961836;
   _f.__stackDetails = _e;
@@ -366,7 +366,7 @@ exports[`babel plugin workletizes getter 1`] = `
 var _classCallCheck2 = _interopRequireDefault(require(\\"@babel/runtime/helpers/classCallCheck\\"));
 var _createClass2 = _interopRequireDefault(require(\\"@babel/runtime/helpers/createClass\\"));
 var _worklet_10436985806815_init_data = {
-  code: \\"function get(){const{x}=this._closure;return x+2;}\\",
+  code: \\"function get(){const{x}=this.__closure;return x+2;}\\",
   location: \\"${ process.cwd() }/jest tests fixture\\"
 };
 var Foo = function () {
@@ -380,7 +380,7 @@ var Foo = function () {
       var _f = function _f() {
         return x + 2;
       };
-      _f._closure = {
+      _f.__closure = {
         x: x
       };
       _f.__initData = _worklet_10436985806815_init_data;
@@ -412,7 +412,7 @@ var Foo = function () {
       var _f = function _f(x) {
         return x + 2;
       };
-      _f._closure = {};
+      _f.__closure = {};
       _f.__initData = _worklet_16974800582491_init_data;
       _f.__workletHash = 16974800582491;
       _f.__stackDetails = _e;
@@ -433,7 +433,7 @@ var foo = function () {
   var _f = function _f(x) {
     return x + 2;
   };
-  _f._closure = {};
+  _f.__closure = {};
   _f.__initData = _worklet_4679479961836_init_data;
   _f.__workletHash = 4679479961836;
   _f.__stackDetails = _e;
@@ -460,7 +460,7 @@ var Foo = function () {
       var _f = function _f(x) {
         return x + 2;
       };
-      _f._closure = {};
+      _f.__closure = {};
       _f.__initData = _worklet_16974800582491_init_data;
       _f.__workletHash = 16974800582491;
       _f.__stackDetails = _e;
@@ -481,7 +481,7 @@ var foo = function () {
   var _f = function _f(x) {
     return x + 2;
   };
-  _f._closure = {};
+  _f.__closure = {};
   _f.__initData = _worklet_16347365292089_init_data;
   _f.__workletHash = 16347365292089;
   _f.__stackDetails = _e;

--- a/src/plugin/__tests__/index.spec.js
+++ b/src/plugin/__tests__/index.spec.js
@@ -140,7 +140,7 @@ describe("babel plugin", () => {
       enter(path) {
         if (
           path.isAssignmentExpression() &&
-          path.node.left.property.name === "_closure"
+          path.node.left.property.name === "__closure"
         ) {
           closureBindings = path.node.right.properties;
         }
@@ -381,12 +381,12 @@ describe("babel plugin", () => {
   it("supports nested worklets keeping worklet decoration for inner worklet", () => {
     const input = `const f = () => {
       "worklet";
-    
+
       const b = () => {
         "worklet";
         return 200;
       }
-    
+
       return 100 + b();
     }`;
     const { code } = runPlugin(input);

--- a/src/plugin/index.js
+++ b/src/plugin/index.js
@@ -270,7 +270,7 @@ function buildWorkletString(t, fun, closureVariables, name, inputMap) {
             )
           )
         ),
-        t.memberExpression(t.thisExpression(), t.identifier("_closure"))
+        t.memberExpression(t.thisExpression(), t.identifier("__closure"))
       ),
     ]);
 
@@ -533,7 +533,7 @@ function makeWorklet(t, fun, state) {
     t.expressionStatement(
       t.assignmentExpression(
         "=",
-        t.memberExpression(privateFunctionId, t.identifier("_closure"), false),
+        t.memberExpression(privateFunctionId, t.identifier("__closure"), false),
         closureGenerator.generate(t, variables, closure.keys())
       )
     ),


### PR DESCRIPTION
In the latest version of Reanimated, they renamed `_closure` to `__closure`. cc @tomekzaw

### Related

- https://github.com/software-mansion/react-native-reanimated/pull/4803
- https://github.com/mrousavy/react-native-vision-camera/issues/1767