### PR TITLE
Added disposing/release mechanism to the system

### DIFF
--- a/cpp/WKTJsiWorklet.h
+++ b/cpp/WKTJsiWorklet.h
@@ -301,7 +301,7 @@ private:
                       .asString(runtime)
                       .utf8(runtime);
     }
-    
+
     // Double-check if the code property is valid.
     bool isCodeEmpty = std::all_of(_code.begin(), _code.end(), std::isspace);
     if (isCodeEmpty) {

--- a/cpp/base/WKTJsiHostObject.cpp
+++ b/cpp/base/WKTJsiHostObject.cpp
@@ -31,6 +31,13 @@ JsiHostObject::~JsiHostObject() {
 #endif
 }
 
+void JsiHostObject::dispose() {
+  if (!_disposed) {
+    dispose(_disposed);
+    _disposed = true;
+  }
+}
+
 void JsiHostObject::set(jsi::Runtime &rt, const jsi::PropNameID &name,
                         const jsi::Value &value) {
 

--- a/cpp/base/WKTJsiHostObject.h
+++ b/cpp/base/WKTJsiHostObject.h
@@ -143,6 +143,11 @@ public:
   JsiHostObject();
   ~JsiHostObject();
 
+  /**
+   Disposes and releases all used resources
+   */
+  void dispose();
+
 protected:
   /**
    Override to return map of name/functions
@@ -194,7 +199,13 @@ protected:
    */
   std::vector<jsi::PropNameID> getPropertyNames(jsi::Runtime &runtime) override;
 
+  /**
+   Override to dispose
+   */
+  virtual void dispose(bool disposed) {}
+
 private:
   std::map<void *, std::map<std::string, jsi::Function>> _hostFunctionCache;
+  std::atomic<bool> _disposed = {false};
 };
 } // namespace RNWorklet

--- a/cpp/sharedvalues/WKTJsiSharedValue.h
+++ b/cpp/sharedvalues/WKTJsiSharedValue.h
@@ -30,6 +30,11 @@ public:
    */
   ~JsiSharedValue() { _valueWrapper = nullptr; }
 
+  JSI_HOST_FUNCTION(dispose) {
+    JsiHostObject::dispose();
+    return jsi::Value::undefined();
+  }
+
   JSI_HOST_FUNCTION(toString) {
     return jsi::String::createFromUtf8(runtime,
                                        _valueWrapper->toString(runtime));
@@ -100,6 +105,7 @@ public:
   }
 
   JSI_EXPORT_FUNCTIONS(JSI_EXPORT_FUNC(JsiSharedValue, toString),
+                       JSI_EXPORT_FUNC(JsiSharedValue, dispose),
                        JSI_EXPORT_FUNC(JsiSharedValue, addListener))
 
   JSI_EXPORT_PROPERTY_GETTERS(JSI_EXPORT_PROP_GET(JsiSharedValue, value))
@@ -120,6 +126,13 @@ public:
    */
   void removeListener(size_t listenerId) {
     _valueWrapper->removeListener(listenerId);
+  }
+
+protected:
+  void dispose(bool disposed) override {
+    if (!disposed) {
+      _valueWrapper->release_wrapped_resources();
+    }
   }
 
 private:

--- a/cpp/wrappers/WKTArgumentsWrapper.h
+++ b/cpp/wrappers/WKTArgumentsWrapper.h
@@ -20,6 +20,12 @@ public:
     }
   }
 
+  ~ArgumentsWrapper() {
+    for (size_t i = 0; i < _arguments.size(); i++) {
+      _arguments[i]->release_wrapped_resources();
+    }
+  }
+
   size_t getCount() const { return _count; }
 
   std::vector<jsi::Value> getArguments(jsi::Runtime &runtime) const {

--- a/cpp/wrappers/WKTJsiArrayWrapper.h
+++ b/cpp/wrappers/WKTJsiArrayWrapper.h
@@ -32,6 +32,8 @@ public:
                   JsiWrapper *parent)
       : JsiWrapper(runtime, value, parent, JsiWrapperType::Array) {}
 
+  ~JsiArrayWrapper() { JsiHostObject::dispose(); }
+
   JSI_HOST_FUNCTION(toStringImpl) {
     return jsi::String::createFromUtf8(runtime, toString(runtime));
   }
@@ -412,6 +414,18 @@ public:
   }
 
   const std::vector<std::shared_ptr<JsiWrapper>> &getArray() { return _array; }
+
+  /**
+    Overridden dispose - release our array resources!
+   */
+  void release_wrapped_resources() override {
+    for (size_t i = 0; i < _array.size(); i++) {
+      _array[i]->release_wrapped_resources();
+    }
+  }
+
+protected:
+  void dispose(bool disposed) override { release_wrapped_resources(); }
 
 private:
   /**

--- a/cpp/wrappers/WKTJsiPromiseWrapper.h
+++ b/cpp/wrappers/WKTJsiPromiseWrapper.h
@@ -78,7 +78,20 @@ public:
 
   explicit JsiPromiseWrapper(jsi::Runtime &runtime);
 
-  ~JsiPromiseWrapper() {}
+  ~JsiPromiseWrapper() { JsiHostObject::dispose(); }
+
+  /**
+    Overridden dispose - release our array resources!
+   */
+  void release_wrapped_resources() override {
+    if (_reason != nullptr) {
+      _reason->release_wrapped_resources();
+    }
+    if (_value != nullptr) {
+      _value->release_wrapped_resources();
+    }
+  }
+
   /**
    Returns true if the object is a thenable object - ie. an object with a then
    function. Which is basically what a promise is.
@@ -138,6 +151,12 @@ public:
   }
 
 protected:
+  void dispose(bool disposed) override {
+    if (!disposed) {
+      release_wrapped_resources();
+    }
+  }
+
   jsi::Value then(jsi::Runtime &runtime, const jsi::Value &thisValue,
                   const jsi::Value *thenFn, const jsi::Value *catchFn);
 

--- a/cpp/wrappers/WKTJsiWrapper.h
+++ b/cpp/wrappers/WKTJsiWrapper.h
@@ -137,6 +137,11 @@ public:
    */
   void removeListener(size_t listenerId) { _listeners.erase(listenerId); }
 
+  /**
+    Override to ensure releasing resources correctly
+   */
+  virtual void release_wrapped_resources() {}
+
 protected:
   /**
    * Returns a wrapper for the value
@@ -185,7 +190,6 @@ protected:
                           const jsi::Value &thisValue,
                           const jsi::Value *arguments, size_t count);
 
-protected:
   /**
    * Sets the value from a JS value
    * @param runtime runtime for the value
@@ -253,10 +257,10 @@ private:
    * @param parent Parent wrapper
    */
   explicit JsiWrapper(JsiWrapper *parent) : _parent(parent) {
-    _readWriteMutex = new std::mutex();
+    _readWriteMutex = std::make_shared<std::mutex>();
   }
 
-  std::mutex *_readWriteMutex;
+  std::shared_ptr<std::mutex> _readWriteMutex;
   JsiWrapper *_parent;
 
   JsiWrapperType _type;

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,7 @@ export interface ISharedValue<T> {
   get value(): T;
   set value(v: T);
   addListener(listener: () => void): () => void;
+  dispose: () => void;
 }
 
 export interface IWorklet {


### PR DESCRIPTION
To make sure we free any underlying values due to the dreaded hermes GC issue where internally allocated memory is not calcualated when considering garbage collection we need to implement this ourselves.

A shared value is now disposed and all resources allocated should be released. This is done through wrappers.

When deleting argument wrappers we also release any resources.

Fixes #129