### PR TITLE
fix: Remove `jni::ThreadScope` and fbjni dependency

### DIFF
--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -16,7 +16,6 @@ include("${REACT_NATIVE_DIR}/ReactAndroid/cmake-utils/folly-flags.cmake")
 add_compile_options(${folly_FLAGS})
 
 # Consume shared libraries and headers from prefabs
-find_package(fbjni REQUIRED CONFIG)
 find_package(ReactAndroid REQUIRED CONFIG)
 
 if(${JS_RUNTIME} STREQUAL "hermes")
@@ -63,7 +62,6 @@ target_link_libraries(
   ReactAndroid::glog
   ReactAndroid::jsi
   ReactAndroid::reactnativejni
-  fbjni::fbjni
 )
 
 if(${JS_RUNTIME} STREQUAL "hermes")

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -137,7 +137,6 @@ android {
       "META-INF",
       "META-INF/**",
       "**/libc++_shared.so",
-      "**/libfbjni.so",
       "**/libjsi.so",
       "**/libfolly_json.so",
       "**/libfolly_runtime.so",

--- a/cpp/WKTJsiWorkletContext.cpp
+++ b/cpp/WKTJsiWorkletContext.cpp
@@ -23,10 +23,6 @@
 
 #include <jsi/jsi.h>
 
-#ifdef ANDROID
-#include <fbjni/fbjni.h>
-#endif
-
 namespace RNWorklet {
 
 const char *WorkletRuntimeFlag = "__rn_worklets_runtime_flag";
@@ -144,9 +140,6 @@ void JsiWorkletContext::invokeOnWorkletThread(
   _workletCallInvoker([fp = std::move(fp), weakSelf = weak_from_this()]() {
     auto self = weakSelf.lock();
     if (self) {
-#ifdef ANDROID
-      facebook::jni::ThreadScope scope;
-#endif
       fp(self.get(), self->getWorkletRuntime());
     }
   });


### PR DESCRIPTION
Removes the `jni::ThreadScope` and fbjni dependency from react-native-worklets-core, as it is implementation specific and we cannot always assume that the user wants a ThreadScope (this is also a performance impact).

Instead, the user should implement using a ThreadScope themselves, either via `ThreadScope` or `ThreadScope::WithClassLoader`.

cc @chrfalch 