### PR TITLE
fix: Use `ThreadScope::WithClassLoader` to access custom JNI fields

### DIFF
--- a/cpp/WKTJsiWorkletContext.cpp
+++ b/cpp/WKTJsiWorkletContext.cpp
@@ -145,9 +145,12 @@ void JsiWorkletContext::invokeOnWorkletThread(
     auto self = weakSelf.lock();
     if (self) {
 #ifdef ANDROID
-      facebook::jni::ThreadScope scope;
-#endif
+      facebook::jni::ThreadScope::WithClassLoader([fp = std::move(fp), self]() {
+        fp(self.get(), self->getWorkletRuntime());
+      });
+#else
       fp(self.get(), self->getWorkletRuntime());
+#endif
     }
   });
 }


### PR DESCRIPTION
Uses `ThreadScope::WithClassLoader` instead of just a normal `ThreadScope` so that we also have access to the custom JNI classes that might have been created by the application.

The normal ThreadScope just has access to everything that has been loaded by the System before.

Fixes https://github.com/mrousavy/react-native-vision-camera/issues/1791