### PR TITLE
feat: Add `BigInt64Array` support

### DIFF
--- a/src/plugin/index.js
+++ b/src/plugin/index.js
@@ -29,6 +29,8 @@ const globals = new Set([
   "Uint32Array",
   "Float32Array",
   "Float64Array",
+  "BigInt64Array",
+  "BigUint64Array",
   "Date",
   "HermesInternal",
   "JSON",


### PR DESCRIPTION
Adds two new typed array types to the Worklet Runtimes: [`BigInt64Array`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt64Array) and [`BigUint64Array`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigUint64Array), which are probably only supported through Hermes or JS polyfills.

With this change, the plugin also allows you to use those big-int arrays in your Worklets, assuming they are natively supported in the JS Runtime you are using (Hermes).

Needed by https://github.com/mrousavy/react-native-fast-tflite/pull/49