### PR TITLE
fix: added missing export of useRunInJS

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import "./NativeWorklets";
 export * from "./types";
+export * from "./hooks/useRunInJS";
 export * from "./hooks/useSharedValue";
 export * from "./hooks/useWorklet";


### PR DESCRIPTION
Fixed missing export for the `useRunInJS` hook that was added in https://github.com/margelo/react-native-worklets-core/pull/139