### PR TITLE
feat: Add `shift` function to `JsiArrayWrapper`

### DIFF
--- a/cpp/wrappers/WKTJsiArrayWrapper.h
+++ b/cpp/wrappers/WKTJsiArrayWrapper.h
@@ -86,6 +86,17 @@ public:
     return lastEl->unwrapAsProxyOrValue(runtime);
   };
 
+  JSI_HOST_FUNCTION(shift) {
+    // Shift first element from array
+    if (_array.empty()) {
+      return jsi::Value::undefined();
+    }
+    auto firstEl = _array.at(0);
+    _array.erase(_array.begin());
+    notify();
+    return firstEl->unwrapAsProxyOrValue(runtime);
+  };
+
   JSI_HOST_FUNCTION(forEach) {
     auto callbackFn = arguments[0].asObject(runtime).asFunction(runtime);
     for (size_t i = 0; i < _array.size(); i++) {
@@ -275,6 +286,7 @@ public:
   JSI_EXPORT_FUNCTIONS(
       JSI_EXPORT_FUNC(JsiArrayWrapper, push),
       JSI_EXPORT_FUNC(JsiArrayWrapper, pop),
+      JSI_EXPORT_FUNC(JsiArrayWrapper, shift),
       JSI_EXPORT_FUNC(JsiArrayWrapper, forEach),
       JSI_EXPORT_FUNC(JsiArrayWrapper, map),
       JSI_EXPORT_FUNC(JsiArrayWrapper, filter),

--- a/example/Tests/wrapper-tests.ts
+++ b/example/Tests/wrapper-tests.ts
@@ -57,6 +57,24 @@ export const wrapper_tests = {
     return ExpectValue(array.value.length, 1);
   },
 
+  array_pop_values: () => {
+    const array = Worklets.createSharedValue([100, 200]);
+    array.value.pop();
+    return ExpectValue(array.value[0], 100);
+  },
+
+  array_shift: () => {
+    const array = Worklets.createSharedValue([100, 200]);
+    array.value.shift();
+    return ExpectValue(array.value.length, 1);
+  },
+
+  array_shift_values: () => {
+    const array = Worklets.createSharedValue([100, 200]);
+    array.value.shift();
+    return ExpectValue(array.value[0], 200);
+  },
+
   array_forEach: () => {
     const array = Worklets.createSharedValue([100, 200]);
     let sum = 0;


### PR DESCRIPTION
This adds a new function to the `JsiArrayWrapper` Proxy implementation that proxies JS arrays:
`shift()` following the method in Javascript it removes the first element of the array in place and returns this element.