### PR TITLE
Reproduction issue: context not getting deallocated

### DIFF
--- a/cpp/WKTJsiWorkletContext.cpp
+++ b/cpp/WKTJsiWorkletContext.cpp
@@ -25,6 +25,7 @@
 
 #ifdef ANDROID
 #include <fbjni/fbjni.h>
+#include <android/log.h>
 #endif
 
 namespace RNWorklet {
@@ -64,12 +65,15 @@ JsiWorkletContext::JsiWorkletContext(
 JsiWorkletContext::~JsiWorkletContext() {
   // Remove from thread contexts
   runtimeMappings.erase(&_workletRuntime);
+  __android_log_print(ANDROID_LOG_INFO, "JsiWorkletContext", "JsiWorkletContext::~JsiWorkletContext(%s)", _name.c_str());
 }
 
 void JsiWorkletContext::initialize(
     const std::string &name, jsi::Runtime *jsRuntime,
     std::function<void(std::function<void()> &&)> jsCallInvoker,
     std::function<void(std::function<void()> &&)> workletCallInvoker) {
+__android_log_print(ANDROID_LOG_INFO, "JsiWorkletContext", "JsiWorkletContext::initialize(%s)", name.c_str());
+
   _name = name;
   _jsRuntime = jsRuntime;
   _jsCallInvoker = jsCallInvoker;

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,84 +1,22 @@
-import React from "react";
-import {
-  ScrollView,
-  StyleSheet,
-  Text,
-  TouchableOpacity,
-  View,
-} from "react-native";
-
-import { useTestRunner } from "../Tests";
-import { TestWrapper } from "../Tests/TestWrapper";
+import { useEffect } from "react";
+import { Worklets } from "react-native-worklets-core";
 
 const App = () => {
-  const { tests, categories, output, runTests, runSingleTest } =
-    useTestRunner();
-  return (
-    <View style={styles.container}>
-      <View style={styles.tests}>
-        <ScrollView
-          contentInsetAdjustmentBehavior="automatic"
-          contentContainerStyle={styles.testsScrollView}
-        >
-          {categories.map((category) => (
-            <React.Fragment key={category}>
-              <TouchableOpacity
-                onPress={() =>
-                  runTests(tests.filter((t) => t.category === category))
-                }
-              >
-                <Text style={styles.category}>{category}</Text>
-              </TouchableOpacity>
-              {tests
-                .filter((t) => t.category === category)
-                .map((t) => (
-                  <TestWrapper
-                    key={t.name}
-                    name={t.name}
-                    state={t.state}
-                    onRun={() => runSingleTest(t)}
-                  />
-                ))}
-            </React.Fragment>
-          ))}
-        </ScrollView>
-      </View>
-      <View style={styles.output}>
-        <ScrollView>
-          <Text style={styles.outputText}>{output.join("\n")}</Text>
-        </ScrollView>
-      </View>
-    </View>
-  );
-};
+  useEffect(() => {
+    const workeltFunctionA = () => {
+      "worklet";
+    };
 
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-  },
-  tests: {
-    paddingTop: 34,
-    flex: 1,
-  },
-  testsScrollView: {
-    paddingTop: 24,
-    paddingBottom: 40,
-  },
-  output: {
-    borderTopColor: "#CCC",
-    borderTopWidth: StyleSheet.hairlineWidth,
-    flex: 0.2,
-    backgroundColor: "#EFEFEF",
-  },
-  outputText: {
-    padding: 8,
-  },
-  category: {
-    paddingTop: 8,
-    paddingBottom: 4,
-    paddingHorizontal: 8,
-    textDecorationLine: "underline",
-  },
-});
+    Worklets.createRunInContextFn(() => {
+      "worklet";
+      function innerFct() {
+        workeltFunctionA();
+      }
+      innerFct();
+    });
+  }, []);
+
+  return null;
+};
 
 export default App;


### PR DESCRIPTION
There is an issue that happens when you have nested worklet functions where e.g. on a reload the isn't deallocated (ie. its destructor isn't called).
This is problematic as all references the context potentially holds a reference to won't be deallocated either. 


https://github.com/margelo/react-native-worklets-core/assets/16821682/9bb384e0-e024-4b20-87b1-5a09cd7f30da

cc @chrfalch @mrousavy 