### PR TITLE
Fix/154: Better control over memory deallocation

### DIFF
--- a/cpp/WKTJsiWorklet.h
+++ b/cpp/WKTJsiWorklet.h
@@ -10,6 +10,7 @@
 #include "WKTJsiHostObject.h"
 #include "WKTJsiWorkletContext.h"
 #include "WKTJsiWrapper.h"
+#include "WKTRuntimeAwareCache.h"
 
 namespace RNWorklet {
 
@@ -356,51 +357,17 @@ public:
   WorkletInvoker(jsi::Runtime &runtime, const jsi::Value &value)
       : WorkletInvoker(std::make_shared<JsiWorklet>(runtime, value)) {}
 
-  ~WorkletInvoker() {
-    // RUNTIME TEARDOWN:
-    // Ensure we destruct in the same runtime / context as we
-    // created the workletFunction. The way we do this is that
-    // when we save the _workletFunction we also save a shared_ptr
-    // to the current context - and then in the destructor we make
-    // sure that we destroy the _workletFunction (jsi::Function) from
-    // within the same context as we created it.
-    if (_workletFunction) {
-      // Save to temp and remove current value so that the
-      // reference count goes down to 1 before we move it into
-      // the contexts.
-      auto tmp = _workletFunction;
-      _workletFunction = nullptr;
-
-      if (_owningContext == nullptr) {
-        // Javascript
-        JsiWorkletContext::getDefaultInstance()->invokeOnJsThread(
-            [tmp = std::move(tmp)](jsi::Runtime &) mutable { tmp = nullptr; });
-      } else {
-        _owningContext->invokeOnWorkletThread(
-            [tmp = std::move(tmp)](JsiWorkletContext *,
-                                   jsi::Runtime &) mutable { tmp = nullptr; });
-      }
-    }
-  }
-
   jsi::Value call(jsi::Runtime &runtime, const jsi::Value &thisValue,
                   const jsi::Value *arguments, size_t count) {
-    if (_workletFunction == nullptr) {
-      _workletFunction = _worklet->createWorkletJsFunction(runtime);
-      auto owningContext = JsiWorkletContext::getCurrent(runtime);
-      if (owningContext) {
-        _owningContext = owningContext->shared_from_this();
-      } else {
-        _owningContext = nullptr;
-      }
+    if (_workletFunction.get(runtime) == nullptr) {
+      _workletFunction.get(runtime) = _worklet->createWorkletJsFunction(runtime);      
     }
-    return _worklet->call(_workletFunction, runtime, thisValue, arguments,
+    return _worklet->call(_workletFunction.get(runtime), runtime, thisValue, arguments,
                           count);
   }
 
 private:
-  std::shared_ptr<JsiWorkletContext> _owningContext;
+  RuntimeAwareCache<std::shared_ptr<jsi::Function>> _workletFunction;
   std::shared_ptr<JsiWorklet> _worklet;
-  std::shared_ptr<jsi::Function> _workletFunction;
 };
 } // namespace RNWorklet

--- a/cpp/WKTJsiWorkletApi.cpp
+++ b/cpp/WKTJsiWorkletApi.cpp
@@ -23,7 +23,7 @@ std::shared_ptr<JsiWorkletApi> JsiWorkletApi::instance;
  * Installs the worklet API into the provided runtime
  */
 void JsiWorkletApi::installApi(jsi::Runtime &runtime) {
-  auto context = JsiWorkletContext::getDefaultInstance();
+  JsiWorkletContext::getDefaultInstance();
   auto existingApi = (runtime.global().getProperty(runtime, WorkletsApiName));
   if (existingApi.isObject()) {
     return;

--- a/cpp/WKTJsiWorkletApi.h
+++ b/cpp/WKTJsiWorkletApi.h
@@ -59,7 +59,7 @@ public:
     return jsi::Object::createFromHostObject(
         *JsiWorkletContext::getDefaultInstance()->getJsRuntime(),
         std::make_shared<JsiSharedValue>(
-            arguments[0], JsiWorkletContext::getDefaultInstance()));
+            arguments[0], JsiWorkletContext::getDefaultInstanceAsShared()));
   };
 
   JSI_HOST_FUNCTION(createRunInJsFn) {
@@ -98,11 +98,12 @@ public:
     }
 
     // Get the active context
-    auto activeContext =
-        count == 2 && arguments[1].isObject()
-            ? arguments[1].asObject(runtime).getHostObject<JsiWorkletContext>(
-                  runtime)
-            : JsiWorkletContext::getDefaultInstance();
+    auto activeContext = count == 2 && arguments[1].isObject()
+                             ? arguments[1]
+                                   .asObject(runtime)
+                                   .getHostObject<JsiWorkletContext>(runtime)
+                                   .get()
+                             : JsiWorkletContext::getDefaultInstance();
 
     if (activeContext == nullptr) {
       throw jsi::JSError(runtime,
@@ -110,7 +111,7 @@ public:
     }
 
     auto caller = JsiWorkletContext::createCallInContext(runtime, arguments[0],
-                                                         activeContext.get());
+                                                         activeContext);
 
     // Now let us create the caller function.
     return jsi::Function::createFromHostFunction(
@@ -127,14 +128,15 @@ public:
 
   JSI_PROPERTY_GET(defaultContext) {
     return jsi::Object::createFromHostObject(
-        runtime, JsiWorkletContext::getDefaultInstance());
+        runtime, JsiWorkletContext::getDefaultInstanceAsShared());
   }
 
   JSI_PROPERTY_GET(currentContext) {
     auto current = JsiWorkletContext::getCurrent(runtime);
-    if (!current) return jsi::Value::undefined();
-    return jsi::Object::createFromHostObject(
-        runtime, current->shared_from_this());
+    if (!current)
+      return jsi::Value::undefined();
+    return jsi::Object::createFromHostObject(runtime,
+                                             current->shared_from_this());
   }
 
   JSI_EXPORT_PROPERTY_GETTERS(JSI_EXPORT_PROP_GET(JsiWorkletApi,

--- a/cpp/WKTJsiWorkletApi.h
+++ b/cpp/WKTJsiWorkletApi.h
@@ -58,8 +58,7 @@ public:
   JSI_HOST_FUNCTION(createSharedValue) {
     return jsi::Object::createFromHostObject(
         *JsiWorkletContext::getDefaultInstance()->getJsRuntime(),
-        std::make_shared<JsiSharedValue>(
-            arguments[0], JsiWorkletContext::getDefaultInstanceAsShared()));
+        std::make_shared<JsiSharedValue>(arguments[0]));
   };
 
   JSI_HOST_FUNCTION(createRunInJsFn) {

--- a/cpp/WKTJsiWorkletContext.cpp
+++ b/cpp/WKTJsiWorkletContext.cpp
@@ -1,6 +1,7 @@
 
 #include "WKTJsiWorkletContext.h"
 #include "WKTJsiWorkletApi.h"
+#include "WKTRuntimeAwareCache.h"
 
 #include "WKTArgumentsWrapper.h"
 #include "WKTDispatchQueue.h"
@@ -70,6 +71,10 @@ void JsiWorkletContext::initialize(
     const std::string &name, jsi::Runtime *jsRuntime,
     std::function<void(std::function<void()> &&)> jsCallInvoker,
     std::function<void(std::function<void()> &&)> workletCallInvoker) {
+
+  // Register main runtime
+  BaseRuntimeAwareCache::setMainJsRuntime(jsRuntime);
+  
   _name = name;
   _jsRuntime = jsRuntime;
   _jsCallInvoker = jsCallInvoker;

--- a/cpp/WKTJsiWorkletContext.h
+++ b/cpp/WKTJsiWorkletContext.h
@@ -92,13 +92,22 @@ public:
                   std::function<void(std::function<void()> &&)> jsCallInvoker);
 
   /**
-   Static / singleton default context
+   Get the default context
    */
-  static std::shared_ptr<JsiWorkletContext> getDefaultInstance() {
+  static std::shared_ptr<JsiWorkletContext> getDefaultInstanceAsShared() {
     if (defaultInstance == nullptr) {
       defaultInstance = std::make_shared<JsiWorkletContext>();
     }
     return defaultInstance;
+  }
+
+/**
+ * @brief Get the Default Instance object
+ * 
+ * @return JsiWorkletContext* 
+ */
+  static JsiWorkletContext *getDefaultInstance() {
+    return JsiWorkletContext::getDefaultInstanceAsShared().get();
   }
 
   /**

--- a/cpp/base/WKTJsiHostObject.h
+++ b/cpp/base/WKTJsiHostObject.h
@@ -2,6 +2,8 @@
 
 #include <jsi/jsi.h>
 
+#include "WKTRuntimeAwareCache.h"
+
 #include <functional>
 #include <map>
 #include <memory>
@@ -195,6 +197,6 @@ protected:
   std::vector<jsi::PropNameID> getPropertyNames(jsi::Runtime &runtime) override;
 
 private:
-  std::map<void *, std::map<std::string, jsi::Function>> _hostFunctionCache;
+  RuntimeAwareCache<std::map<std::string, jsi::Function>> _hostFunctionCache;
 };
 } // namespace RNWorklet

--- a/cpp/base/WKTRuntimeAwareCache.cpp
+++ b/cpp/base/WKTRuntimeAwareCache.cpp
@@ -1,0 +1,7 @@
+#include "WKTRuntimeAwareCache.h"
+
+namespace RNWorklet {
+
+jsi::Runtime *BaseRuntimeAwareCache::_mainRuntime = nullptr;
+
+} // namespace RNWorklet

--- a/cpp/base/WKTRuntimeAwareCache.h
+++ b/cpp/base/WKTRuntimeAwareCache.h
@@ -1,0 +1,101 @@
+#pragma once
+
+#include <jsi/jsi.h>
+
+#include <memory>
+#include <unordered_map>
+#include <utility>
+
+#include "WKTRuntimeLifecycleMonitor.h"
+
+namespace RNWorklet {
+
+namespace jsi = facebook::jsi;
+
+class BaseRuntimeAwareCache {
+public:
+  static void setMainJsRuntime(jsi::Runtime *rt) { _mainRuntime = rt; }
+
+protected:
+  static jsi::Runtime *getMainJsRuntime() {
+    assert(_mainRuntime != nullptr &&
+           "Expected main Javascript runtime to be set in the "
+           "BaseRuntimeAwareCache class.");
+
+    return _mainRuntime;
+  }
+
+private:
+  static jsi::Runtime *_mainRuntime;
+};
+
+/**
+ * Provides a way to keep data specific to a jsi::Runtime instance that gets
+ * cleaned up when that runtime is destroyed. This is necessary because JSI does
+ * not allow for its associated objects to be retained past the runtime
+ * lifetime. If an object (e.g. jsi::Values or jsi::Function instances) is kept
+ * after the runtime is torn down, its destructor (once it is destroyed
+ * eventually) will result in a crash (JSI objects keep a pointer to memory
+ * managed by the runtime, accessing that portion of the memory after runtime is
+ * deleted is the root cause of that crash).
+ *
+ * In order to provide an efficient implementation that does not add an overhead
+ * for the cases when only a single runtiome is used, which is the primary
+ * usecase, the following assumption has been made: Only for secondary runtimes
+ * we track destruction and clean up the store associated with that runtime. For
+ * the first runtime we assume that the object holding the store is destroyed
+ * prior to the destruction of that runtime.
+ *
+ * The above assumption makes it work without any overhead when only single
+ * runtime is in use. Specifically, we don't perform any additional operations
+ * related to tracking runtime lifecycle when only a single runtime is used.
+ */
+template <typename T>
+class RuntimeAwareCache : public BaseRuntimeAwareCache,
+                          public RuntimeLifecycleListener {
+
+public:
+  void onRuntimeDestroyed(jsi::Runtime *rt) override {
+    if (getMainJsRuntime() != rt) {
+      // We are removing a secondary runtime
+      _secondaryRuntimeCaches.erase(rt);
+    }
+  }
+
+  ~RuntimeAwareCache() {
+    for (auto &cache : _secondaryRuntimeCaches) {
+      RuntimeLifecycleMonitor::removeListener(
+          *static_cast<jsi::Runtime *>(cache.first), this);
+    }
+  }
+
+  T &get(jsi::Runtime &rt) {
+    // We check if we're accessing the main runtime - this is the happy path
+    // to avoid us having to lookup by runtime for caches that only has a single
+    // runtime
+    if (getMainJsRuntime() == &rt) {
+      return _primaryCache;
+    } else {
+      if (_secondaryRuntimeCaches.count(&rt) == 0) {
+        // we only add listener when the secondary runtime is used, this assumes
+        // that the secondary runtime is terminated first. This lets us avoid
+        // additional complexity for the majority of cases when objects are not
+        // shared between runtimes. Otherwise we'd have to register all objecrts
+        // with the RuntimeMonitor as opposed to only registering ones that are
+        // used in secondary runtime. Note that we can't register listener here
+        // with the primary runtime as it may run on a separate thread.
+        RuntimeLifecycleMonitor::addListener(rt, this);
+
+        T cache;
+        _secondaryRuntimeCaches.emplace(&rt, std::move(cache));
+      }
+    }
+    return _secondaryRuntimeCaches.at(&rt);
+  }
+
+private:
+  std::unordered_map<void *, T> _secondaryRuntimeCaches;
+  T _primaryCache;
+};
+
+} // namespace RNWorklet

--- a/cpp/base/WKTRuntimeLifecycleMonitor.cpp
+++ b/cpp/base/WKTRuntimeLifecycleMonitor.cpp
@@ -1,0 +1,57 @@
+#include "WKTRuntimeLifecycleMonitor.h"
+
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+
+namespace RNWorklet {
+
+static std::unordered_map<jsi::Runtime *,
+                          std::unordered_set<RuntimeLifecycleListener *>>
+    listeners;
+
+struct RuntimeLifecycleMonitorObject : public jsi::HostObject {
+  jsi::Runtime *_rt;
+  explicit RuntimeLifecycleMonitorObject(jsi::Runtime *rt) : _rt(rt) {}
+  ~RuntimeLifecycleMonitorObject() {
+    auto listenersSet = listeners.find(_rt);
+    if (listenersSet != listeners.end()) {
+      for (auto listener : listenersSet->second) {
+        listener->onRuntimeDestroyed(_rt);
+      }
+      listeners.erase(listenersSet);
+    }
+  }
+};
+
+void RuntimeLifecycleMonitor::addListener(jsi::Runtime &rt,
+                                          RuntimeLifecycleListener *listener) {
+  auto listenersSet = listeners.find(&rt);
+  if (listenersSet == listeners.end()) {
+    // We install a global host object in the provided runtime, this way we can
+    // use that host object destructor to get notified when the runtime is being
+    // terminated. We use a unique name for the object as it gets saved with the
+    // runtime's global object.
+    rt.global().setProperty(
+        rt, "__rnwc_rt_lifecycle_monitor",
+        jsi::Object::createFromHostObject(
+            rt, std::make_shared<RuntimeLifecycleMonitorObject>(&rt)));
+    std::unordered_set<RuntimeLifecycleListener *> newSet;
+    newSet.insert(listener);
+    listeners.emplace(&rt, std::move(newSet));
+  } else {
+    listenersSet->second.insert(listener);
+  }
+}
+
+void RuntimeLifecycleMonitor::removeListener(
+    jsi::Runtime &rt, RuntimeLifecycleListener *listener) {
+  auto listenersSet = listeners.find(&rt);
+  if (listenersSet == listeners.end()) {
+    // nothing to do here
+  } else {
+    listenersSet->second.erase(listener);
+  }
+}
+
+} // namespace RNWorklet

--- a/cpp/base/WKTRuntimeLifecycleMonitor.h
+++ b/cpp/base/WKTRuntimeLifecycleMonitor.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <jsi/jsi.h>
+
+#include <memory>
+
+namespace RNWorklet {
+
+namespace jsi = facebook::jsi;
+
+/**
+ * Listener interface that allows for getting notified when a jsi::Runtime
+ * instance is destroyed.
+ */
+struct RuntimeLifecycleListener {
+  virtual ~RuntimeLifecycleListener() {}
+  virtual void onRuntimeDestroyed(jsi::Runtime *) = 0;
+};
+
+/**
+ * This class provides an API via static methods for registering and
+ * unregistering runtime lifecycle listeners. The listeners can be used to
+ * cleanup any data that references a given jsi::Runtime instance before it gets
+ * destroyed.
+ */
+struct RuntimeLifecycleMonitor {
+  static void addListener(jsi::Runtime &rt, RuntimeLifecycleListener *listener);
+  static void removeListener(jsi::Runtime &rt,
+                             RuntimeLifecycleListener *listener);
+};
+
+} // namespace RNWorklet

--- a/cpp/sharedvalues/WKTJsiSharedValue.h
+++ b/cpp/sharedvalues/WKTJsiSharedValue.h
@@ -20,10 +20,8 @@ public:
    Constructs a shared value - which is a wrapped value that can be accessed in
    a thread safe across two javascript runtimes.
    */
-  JsiSharedValue(const jsi::Value &value,
-                 std::shared_ptr<JsiWorkletContext> context)
-      : _valueWrapper(JsiWrapper::wrap(*context->getJsRuntime(), value)),
-        _context(context) {}
+  JsiSharedValue(const jsi::Value &value)
+      : _valueWrapper(JsiWrapper::wrap(*JsiWorkletContext::getDefaultInstance()->getJsRuntime(), value)) {}
 
   /**
     Destructor
@@ -79,7 +77,7 @@ public:
     auto dispatcher = JsiDispatcher::createDispatcher(
         runtime, thisValuePtr, functionPtr, nullptr,
         [&runtime, this](const char *err) {
-          _context->invokeOnJsThread([err](jsi::Runtime &runtime) {
+          JsiWorkletContext::getCurrent(runtime)->invokeOnJsThread([err](jsi::Runtime &runtime) {
             throw jsi::JSError(runtime, err);
           });
         });
@@ -123,7 +121,6 @@ public:
   }
 
 private:
-  std::shared_ptr<JsiWrapper> _valueWrapper;
-  std::shared_ptr<JsiWorkletContext> _context;
+  std::shared_ptr<JsiWrapper> _valueWrapper;  
 };
 } // namespace RNWorklet

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -48,6 +48,7 @@ target 'WorkletsExample' do
     installer.pods_project.targets.each do |target|
       target.build_configurations.each do |config|
         config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '12.4'
+        config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] ||= ['$(inherited)', '_LIBCPP_ENABLE_CXX17_REMOVED_UNARY_BINARY_FUNCTION']        
       end
     end
     __apply_Xcode_12_5_M1_post_install_workaround(installer)


### PR DESCRIPTION
To avoid keeping references to shared_ptrs that are never released, we need to make sure they are destructed on the same runtime.

This is solved by using the RuntimeAwareCache model as in Skia to make sure these key objects are only released together with the runtime they belong in.

More information can be found in the comments of the WKTRuntimeAwareCache.h file.

WKTJsiWorklet.h:
Removed the runtime teardown code from the WorkletInvoker's destructor. This is now taken care of by using the RuntimeAwareCache

WKTJsiWorkletApi.h:
Removed the passing of the default WorkletContext when creating new JsiSharedValues - the thing we want is the runtime and we can get it ourselves inside the shared value ctor.

WKTJsiWorkletContext.cpp:
Added setting the main JS Runtime on the RuntimeAwareCache so that its logic is correctly performed.

WKTJsiHostObject.h/cpp:
- Changed using RuntimeAwareCache for JSI object host functions

General:
To avoid creating extra and unessecary shared pointers of JsiWorkletContext, we now pass it around as a pointer instead of making shared_ptrs all over.

Podfile:
- Added fix with _LIBCPP_ENABLE_CXX17_REMOVED_UNARY_BINARY_FUNCTION error in XCode
