### PR TITLE
fix(types): fix `useRunInJS` type not allowing functions to have args

### DIFF
--- a/src/hooks/useRunInJS.ts
+++ b/src/hooks/useRunInJS.ts
@@ -10,7 +10,7 @@ import { DependencyList, useMemo } from "react";
  */
 export function useRunInJS<
   TResult,
-  TArguments extends [],
+  TArguments extends any[],
   T extends (...args: TArguments) => TResult
 >(
   callback: T,


### PR DESCRIPTION
The current type of `useRunInJS` doesn't allow any argument.
`[]` to `any[]` allows arguments in arbitrary length.