### PR TITLE
feat: Lock Array and Object wrappers for safe multithreading

### DIFF
--- a/cpp/wrappers/WKTJsiObjectWrapper.h
+++ b/cpp/wrappers/WKTJsiObjectWrapper.h
@@ -64,7 +64,7 @@ public:
     }
     updateNativeState(runtime, object);
   }
-                           
+
    void updateNativeState(jsi::Runtime& runtime, jsi::Object& obj) {
      if (obj.hasNativeState(runtime)) {
        _nativeState = obj.getNativeState(runtime);
@@ -86,7 +86,7 @@ public:
     }
     return obj;
   }
-                           
+
    jsi::Object getObject(jsi::Runtime& runtime) {
      switch (getType()) {
      case JsiWrapperType::HostObject:
@@ -112,6 +112,8 @@ public:
    */
   void set(jsi::Runtime &runtime, const jsi::PropNameID &name,
            const jsi::Value &value) override {
+    std::unique_lock lock(_readWriteMutex);
+
     auto nameStr = name.utf8(runtime);
     if (_properties.count(nameStr) == 0) {
       _properties.emplace(nameStr, JsiWrapper::wrap(runtime, value, this));
@@ -127,6 +129,8 @@ public:
    * @return Property value or undefined.
    */
   jsi::Value get(jsi::Runtime &runtime, const jsi::PropNameID &name) override {
+    std::unique_lock lock(_readWriteMutex);
+
     auto nameStr = name.utf8(runtime);
     if (_properties.count(nameStr) != 0) {
       auto prop = _properties.at(nameStr);

--- a/cpp/wrappers/WKTJsiWrapper.cpp
+++ b/cpp/wrappers/WKTJsiWrapper.cpp
@@ -8,7 +8,8 @@ namespace RNWorklet {
 namespace jsi = facebook::jsi;
 
 jsi::Value JsiWrapper::getValue(jsi::Runtime &runtime) {
-  std::unique_lock<std::mutex> lock(_readWriteMutex);
+  std::unique_lock lock(_readWriteMutex);
+
   switch (_type) {
   case JsiWrapperType::Undefined:
     return jsi::Value::undefined();
@@ -79,7 +80,8 @@ void JsiWrapper::setValue(jsi::Runtime &runtime, const jsi::Value &value) {
 }
 
 void JsiWrapper::updateValue(jsi::Runtime &runtime, const jsi::Value &value) {
-  std::unique_lock<std::mutex> lock(_readWriteMutex);
+  std::unique_lock lock(_readWriteMutex);
+
   setValue(runtime, value);
   // Notify changes
   notify();

--- a/cpp/wrappers/WKTJsiWrapper.h
+++ b/cpp/wrappers/WKTJsiWrapper.h
@@ -238,6 +238,12 @@ protected:
     return retVal;
   }
 
+protected:
+  /**
+   * Used for locking calls from multiple runtimes.
+   */
+  std::recursive_mutex _readWriteMutex;
+
 private:
   /**
    * Notify listeners that the value has changed
@@ -254,7 +260,6 @@ private:
    */
   explicit JsiWrapper(JsiWrapper *parent) : _parent(parent) {}
 
-  std::mutex _readWriteMutex;
   JsiWrapper *_parent;
 
   JsiWrapperType _type;


### PR DESCRIPTION
Adds locks to array and object wrappers to make multi-threaded access (read or write operations, e.g. `push()` and `pop()`)  safe.

Uses a `recursive_mutex`, might have a small performance impact.