### PR TITLE
feat: Simplify API (`createRunInContextFn` -> `context.runAsync`)

### DIFF
--- a/cpp/WKTJsiWorkletApi.h
+++ b/cpp/WKTJsiWorkletApi.h
@@ -69,14 +69,12 @@ public:
     // Get the worklet function
     if (!arguments[0].isObject()) {
       throw jsi::JSError(
-          runtime,
-          "prepareRunOnJS expects a function as its first parameter.");
+          runtime, "prepareRunOnJS expects a function as its first parameter.");
     }
 
     if (!arguments[0].asObject(runtime).isFunction(runtime)) {
       throw jsi::JSError(
-          runtime,
-          "prepareRunOnJS expects a function as its first parameter.");
+          runtime, "prepareRunOnJS expects a function as its first parameter.");
     }
 
     auto caller =

--- a/cpp/WKTJsiWorkletApi.h
+++ b/cpp/WKTJsiWorkletApi.h
@@ -61,20 +61,20 @@ public:
         std::make_shared<JsiSharedValue>(arguments[0]));
   };
 
-  JSI_HOST_FUNCTION(prepareRunOnJS) {
+  JSI_HOST_FUNCTION(createRunOnJS) {
     if (count != 1) {
-      throw jsi::JSError(runtime, "prepareRunOnJS expects one parameter.");
+      throw jsi::JSError(runtime, "createRunOnJS expects one parameter.");
     }
 
     // Get the worklet function
     if (!arguments[0].isObject()) {
       throw jsi::JSError(
-          runtime, "prepareRunOnJS expects a function as its first parameter.");
+          runtime, "createRunOnJS expects a function as its first parameter.");
     }
 
     if (!arguments[0].asObject(runtime).isFunction(runtime)) {
       throw jsi::JSError(
-          runtime, "prepareRunOnJS expects a function as its first parameter.");
+          runtime, "createRunOnJS expects a function as its first parameter.");
     }
 
     auto caller =
@@ -82,14 +82,14 @@ public:
 
     // Now let us create the caller function.
     return jsi::Function::createFromHostFunction(
-        runtime, jsi::PropNameID::forAscii(runtime, "prepareRunOnJS"), 0,
+        runtime, jsi::PropNameID::forAscii(runtime, "createRunOnJS"), 0,
         JSI_HOST_FUNCTION_LAMBDA {
           return caller(runtime, thisValue, arguments, count);
         });
   }
 
   JSI_HOST_FUNCTION(runOnJS) {
-    jsi::Value value = prepareRunOnJS(runtime, thisValue, arguments, count);
+    jsi::Value value = createRunOnJS(runtime, thisValue, arguments, count);
     jsi::Function func = value.asObject(runtime).asFunction(runtime);
     return func.call(runtime, nullptr, 0);
   }
@@ -123,7 +123,7 @@ public:
 
   JSI_EXPORT_FUNCTIONS(JSI_EXPORT_FUNC(JsiWorkletApi, createSharedValue),
                        JSI_EXPORT_FUNC(JsiWorkletApi, createContext),
-                       JSI_EXPORT_FUNC(JsiWorkletApi, prepareRunOnJS),
+                       JSI_EXPORT_FUNC(JsiWorkletApi, createRunOnJS),
                        JSI_EXPORT_FUNC(JsiWorkletApi, runOnJS),
                        JSI_EXPORT_FUNC(JsiWorkletApi, __jsi_is_array),
                        JSI_EXPORT_FUNC(JsiWorkletApi, __jsi_is_object))

--- a/cpp/WKTJsiWorkletApi.h
+++ b/cpp/WKTJsiWorkletApi.h
@@ -83,9 +83,7 @@ public:
     // Now let us create the caller function.
     return jsi::Function::createFromHostFunction(
         runtime, jsi::PropNameID::forAscii(runtime, "createRunOnJS"), 0,
-        JSI_HOST_FUNCTION_LAMBDA {
-          return caller(runtime, thisValue, arguments, count);
-        });
+        caller);
   }
 
   JSI_HOST_FUNCTION(runOnJS) {

--- a/cpp/WKTJsiWorkletContext.h
+++ b/cpp/WKTJsiWorkletContext.h
@@ -157,9 +157,9 @@ public:
     return jsi::Value::undefined();
   }
 
-  JSI_HOST_FUNCTION(prepareRunAsync) {
+  JSI_HOST_FUNCTION(createRunAsync) {
     if (count != 1) {
-      throw jsi::JSError(runtime, "prepareRunAsync expects one parameter.");
+      throw jsi::JSError(runtime, "createRunAsync expects one parameter.");
     }
 
     auto caller =
@@ -167,20 +167,20 @@ public:
 
     // Now let us create the caller function.
     return jsi::Function::createFromHostFunction(
-        runtime, jsi::PropNameID::forAscii(runtime, "prepareRunAsync"), 0,
+        runtime, jsi::PropNameID::forAscii(runtime, "createRunAsync"), 0,
         JSI_HOST_FUNCTION_LAMBDA {
           return caller(runtime, thisValue, arguments, count);
         });
   }
 
   JSI_HOST_FUNCTION(runAsync) {
-    jsi::Value value = prepareRunAsync(runtime, thisValue, arguments, count);
+    jsi::Value value = createRunAsync(runtime, thisValue, arguments, count);
     jsi::Function func = value.asObject(runtime).asFunction(runtime);
     return func.call(runtime, nullptr, 0);
   }
 
   JSI_EXPORT_FUNCTIONS(JSI_EXPORT_FUNC(JsiWorkletContext, addDecorator),
-                       JSI_EXPORT_FUNC(JsiWorkletContext, prepareRunAsync),
+                       JSI_EXPORT_FUNC(JsiWorkletContext, createRunAsync),
                        JSI_EXPORT_FUNC(JsiWorkletContext, runAsync))
 
   JSI_PROPERTY_GET(name) {

--- a/cpp/WKTJsiWorkletContext.h
+++ b/cpp/WKTJsiWorkletContext.h
@@ -168,9 +168,7 @@ public:
     // Now let us create the caller function.
     return jsi::Function::createFromHostFunction(
         runtime, jsi::PropNameID::forAscii(runtime, "createRunAsync"), 0,
-        JSI_HOST_FUNCTION_LAMBDA {
-          return caller(runtime, thisValue, arguments, count);
-        });
+        caller);
   }
 
   JSI_HOST_FUNCTION(runAsync) {

--- a/cpp/WKTJsiWorkletContext.h
+++ b/cpp/WKTJsiWorkletContext.h
@@ -156,8 +156,32 @@ public:
 
     return jsi::Value::undefined();
   }
+        
+  JSI_HOST_FUNCTION(prepareRunAsync) {
+    if (count != 1) {
+      throw jsi::JSError(
+          runtime, "prepareRunAsync expects one parameter.");
+    }
 
-  JSI_EXPORT_FUNCTIONS(JSI_EXPORT_FUNC(JsiWorkletContext, addDecorator))
+    auto caller = JsiWorkletContext::createCallInContext(runtime, arguments[0], this);
+
+    // Now let us create the caller function.
+    return jsi::Function::createFromHostFunction(
+        runtime, jsi::PropNameID::forAscii(runtime, "prepareRunAsync"), 0,
+        JSI_HOST_FUNCTION_LAMBDA {
+          return caller(runtime, thisValue, arguments, count);
+        });
+  }
+        
+  JSI_HOST_FUNCTION(runAsync) {
+    jsi::Value value = prepareRunAsync(runtime, thisValue, arguments, count);
+    jsi::Function func = value.asObject(runtime).asFunction(runtime);
+    return func.call(runtime, nullptr, 0);
+  }
+
+  JSI_EXPORT_FUNCTIONS(JSI_EXPORT_FUNC(JsiWorkletContext, addDecorator),
+                       JSI_EXPORT_FUNC(JsiWorkletContext, prepareRunAsync),
+                       JSI_EXPORT_FUNC(JsiWorkletContext, runAsync))
 
   JSI_PROPERTY_GET(name) {
     return jsi::String::createFromUtf8(runtime, getName());

--- a/cpp/WKTJsiWorkletContext.h
+++ b/cpp/WKTJsiWorkletContext.h
@@ -156,14 +156,14 @@ public:
 
     return jsi::Value::undefined();
   }
-        
+
   JSI_HOST_FUNCTION(prepareRunAsync) {
     if (count != 1) {
-      throw jsi::JSError(
-          runtime, "prepareRunAsync expects one parameter.");
+      throw jsi::JSError(runtime, "prepareRunAsync expects one parameter.");
     }
 
-    auto caller = JsiWorkletContext::createCallInContext(runtime, arguments[0], this);
+    auto caller =
+        JsiWorkletContext::createCallInContext(runtime, arguments[0], this);
 
     // Now let us create the caller function.
     return jsi::Function::createFromHostFunction(
@@ -172,7 +172,7 @@ public:
           return caller(runtime, thisValue, arguments, count);
         });
   }
-        
+
   JSI_HOST_FUNCTION(runAsync) {
     jsi::Value value = prepareRunAsync(runtime, thisValue, arguments, count);
     jsi::Function func = value.asObject(runtime).asFunction(runtime);

--- a/cpp/base/WKTJsiHostObject.cpp
+++ b/cpp/base/WKTJsiHostObject.cpp
@@ -49,7 +49,7 @@ void JsiHostObject::set(jsi::Runtime &rt, const jsi::PropNameID &name,
 jsi::Value JsiHostObject::get(jsi::Runtime &runtime,
                               const jsi::PropNameID &name) {
   auto nameStr = name.utf8(runtime);
-  auto& cache = _hostFunctionCache.get(runtime);
+  auto &cache = _hostFunctionCache.get(runtime);
 
   // Check function cache
   auto cachedFunc = cache.find(nameStr);

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -7,7 +7,7 @@ react-native-worklets-core can be used either as a standalone library to run Wor
 To run any JS Function on a background Thread, convert it to a worklet. As an example, this is how you can compute the fibonacci sequence in JS, without blocking the main JS Thread:
 
 ```js
-function fibonacci(num: number) {
+const fibonacci = (num: number): number => {
   'worklet'
   if (num <= 1) return num;
   let prev = 0, curr = 1;

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -7,27 +7,40 @@ react-native-worklets-core can be used either as a standalone library to run Wor
 To run any JS Function on a background Thread, convert it to a worklet. As an example, this is how you can compute the fibonacci sequence in JS, without blocking the main JS Thread:
 
 ```js
-const fibonacci = (num: number): number => {
+function fibonacci(num: number) {
   'worklet'
-  if (num <= 1) return 1
-  return fibonacci(num - 1) + fibonacci(num - 2)
+  if (num <= 1) return num;
+  let prev = 0, curr = 1;
+  for (let i = 2; i <= num; i++) {
+    let next = prev + curr;
+    prev = curr;
+    curr = next;
+  }
+  return curr;
 }
 
-const worklet = Worklets.createRunInContextFn(fibonacci)
-const result = await worklet(50)
+const context = Worklets.defaultContext
+const result = await context.runAsync(() => {
+  'worklet'
+  return fibonacci(50)
+})
 console.log(`Fibonacci of 50 is ${result}`)
 ```
 
-Use `createRunInJsFn` to call back to JS:
+Use `runOnJS` to call back to JS:
 
 ```js
-const setAgeJS = Worklets.createRunInJsFn(setAge)
+const [age, setAge] = useState(30)
 
 function something() {
   'worklet'
-  setAgeJS(50)
+  Worklets.runOnJS(() => setAge(50))
 }
 ```
+
+### Memoize
+
+Both the `runAsync` and `runOnJS` functions are convenience methods for `prepareRunAsync` and `prepareRunOnJS`. For frequent calls, prefer the `prepare...` equivalent instead to memoize the caller function.
 
 ### Hooks
 
@@ -82,18 +95,18 @@ function App() {
 }
 ```
 
+The SharedValue will create a C++ based Proxy implementation for Arrays and Objects, so that any read- or write-operations on the Array/Object are thread-safe.
+
 ### Separate Contexts
 
 You can also create specific contexts (Threads) to run Worklets on:
 
 ```js
 const context1 = Worklets.createContext('my-new-thread-1')
-const run = Worklets.createRunInContextFn(() => {
+context1.runAsync(() => {
   'worklet'
   console.log("Hello from context #1!")
-}, context1)
-
-run()
+})
 ```
 
 ...and even nest them without ever crossing the JavaScript Thread:
@@ -101,17 +114,14 @@ run()
 ```js
 const context1 = Worklets.createContext('my-new-thread-1')
 const context2 = Worklets.createContext('my-new-thread-2')
-const run1 = Worklets.createRunInContextFn(() => {
+context1.runAsync(() => {
   'worklet'
   console.log("Hello from context #1!")
-}, context1)
-const run2 = Worklets.createRunInContextFn(() => {
-  'worklet'
-  console.log("Hello from context #2!")
-  run1()
-}, context2)
-
-run2()
+  context2.runAsync(() => {
+    'worklet'
+    console.log("Hello from context #2!")
+  })
+})
 ```
 
 ## Integration

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -40,7 +40,7 @@ function something() {
 
 ### Memoize
 
-Both the `runAsync` and `runOnJS` functions are convenience methods for `prepareRunAsync` and `prepareRunOnJS`. For frequent calls, prefer the `prepare...` equivalent instead to memoize the caller function.
+Both the `runAsync` and `runOnJS` functions are convenience methods for `createRunAsync` and `createRunOnJS`. For frequent calls, prefer the `prepare...` equivalent instead to memoize the caller function.
 
 ### Hooks
 

--- a/docs/WORKLETS.md
+++ b/docs/WORKLETS.md
@@ -35,7 +35,7 @@ await Worklets.defaultContext.runAsync(sayHello)
 Worklets can take parameters and return results. Results are returned as promises.
 
 ```js
-function fibonacci(num: number) {
+const fibonacci = (num: number): number => {
   'worklet'
   if (num <= 1) return num;
   let prev = 0, curr = 1;

--- a/docs/WORKLETS.md
+++ b/docs/WORKLETS.md
@@ -24,16 +24,10 @@ const sayHello = () => {
 ### Run on a background Thread
 
 The function `sayHello` is now prepared to be executed on any Worklet context.
-If you want to call `sayHello` on a default background Thread, build the worklet:
+If you want to call `sayHello` on a default background Thread, just use `runAsync`:
 
 ```js
-const worklet = Worklets.createRunInContextFn(sayHello)
-```
-
-...and then call it:
-
-```js
-worklet()
+await Worklets.defaultContext.runAsync(sayHello)
 ```
 
 ### Parameters and Results
@@ -41,14 +35,23 @@ worklet()
 Worklets can take parameters and return results. Results are returned as promises.
 
 ```js
-const fibonacci = (num: number): number => {
+function fibonacci(num: number) {
   'worklet'
-  if (num <= 1) return 1
-  return fibonacci(num - 1) + fibonacci(num - 2)
+  if (num <= 1) return num;
+  let prev = 0, curr = 1;
+  for (let i = 2; i <= num; i++) {
+    let next = prev + curr;
+    prev = curr;
+    curr = next;
+  }
+  return curr;
 }
 
-const worklet = Worklets.createRunInContextFn(fibonacci)
-const result = await worklet(50)
+const context = Worklets.defaultContext
+const result = await context.runAsync(() => {
+  'worklet'
+  return fibonacci(50)
+})
 console.log(`Fibonacci of 50 is ${result}`)
 ```
 

--- a/example/Tests/sharedvalue-tests.ts
+++ b/example/Tests/sharedvalue-tests.ts
@@ -147,7 +147,7 @@ export const sharedvalue_tests = {
 
   set_value_from_worklet: () => {
     const sharedValue = Worklets.createSharedValue("hello world");
-    const worklet = Worklets.createRunInContextFn(function () {
+    const worklet = Worklets.defaultContext.prepareRunAsync(function () {
       "worklet";
       sharedValue.value = "hello worklet";
     });
@@ -177,7 +177,7 @@ export const sharedvalue_tests = {
   add_listener_from_worklet: () => {
     const sharedValue = Worklets.createSharedValue(100);
     const didChange = Worklets.createSharedValue(false);
-    const w = Worklets.createRunInContextFn(function () {
+    const w = Worklets.defaultContext.prepareRunAsync(function () {
       "worklet";
       const unsubscribe = sharedValue.addListener(
         () => (didChange.value = true)

--- a/example/Tests/sharedvalue-tests.ts
+++ b/example/Tests/sharedvalue-tests.ts
@@ -147,7 +147,7 @@ export const sharedvalue_tests = {
 
   set_value_from_worklet: () => {
     const sharedValue = Worklets.createSharedValue("hello world");
-    const worklet = Worklets.defaultContext.prepareRunAsync(function () {
+    const worklet = Worklets.defaultContext.createRunAsync(function () {
       "worklet";
       sharedValue.value = "hello worklet";
     });
@@ -177,7 +177,7 @@ export const sharedvalue_tests = {
   add_listener_from_worklet: () => {
     const sharedValue = Worklets.createSharedValue(100);
     const didChange = Worklets.createSharedValue(false);
-    const w = Worklets.defaultContext.prepareRunAsync(function () {
+    const w = Worklets.defaultContext.createRunAsync(function () {
       "worklet";
       const unsubscribe = sharedValue.addListener(
         () => (didChange.value = true)

--- a/example/Tests/worklet-context-tests.ts
+++ b/example/Tests/worklet-context-tests.ts
@@ -24,7 +24,7 @@ export const worklet_context_tests = {
       "worklet";
       return a + x;
     };
-    const w = Worklets.defaultContext.prepareRunAsync(f);
+    const w = Worklets.defaultContext.createRunAsync(f);
     return ExpectValue(w(100), 200);
   },
 
@@ -34,7 +34,7 @@ export const worklet_context_tests = {
       "worklet";
       return a;
     };
-    const w = context.prepareRunAsync(f);
+    const w = context.createRunAsync(f);
     return ExpectValue(w(100), 100);
   },
 
@@ -43,7 +43,7 @@ export const worklet_context_tests = {
       "worklet";
       throw new Error("Test error");
     };
-    const w = Worklets.defaultContext.prepareRunAsync(f);
+    const w = Worklets.defaultContext.createRunAsync(f);
     return ExpectException(w, "Test error");
   },
 
@@ -53,7 +53,7 @@ export const worklet_context_tests = {
       "worklet";
       throw new Error("Test error");
     };
-    const w = context.prepareRunAsync(f);
+    const w = context.createRunAsync(f);
     return ExpectException(w, "Test error");
   },
 
@@ -69,7 +69,7 @@ export const worklet_context_tests = {
       workletB(a);
     };
 
-    const w = Worklets.defaultContext.prepareRunAsync(workletA);
+    const w = Worklets.defaultContext.createRunAsync(workletA);
     return Expect(w(100), () => {
       return sharedValue.value === 100
         ? undefined
@@ -84,14 +84,14 @@ export const worklet_context_tests = {
       sharedValue.value = a;
     };
 
-    const js1 = Worklets.prepareRunOnJS(setSharedValue);
+    const js1 = Worklets.createRunOnJS(setSharedValue);
 
     const w1 = function (a: number) {
       "worklet";
       return js1(a);
     };
 
-    const w = Worklets.defaultContext.prepareRunAsync(w1);
+    const w = Worklets.defaultContext.createRunAsync(w1);
     return Expect(w(100), () => {
       return sharedValue.value === 100
         ? undefined
@@ -100,12 +100,12 @@ export const worklet_context_tests = {
   },
 
   call_async_to_js_from_worklet_with_retval: () => {
-    const workletB = Worklets.prepareRunOnJS(function (a: number) {
+    const workletB = Worklets.createRunOnJS(function (a: number) {
       "worklet";
       return a;
     });
 
-    const workletA = Worklets.defaultContext.prepareRunAsync((a: number) => {
+    const workletA = Worklets.defaultContext.createRunAsync((a: number) => {
       "worklet";
       return workletB(a);
     });
@@ -113,12 +113,12 @@ export const worklet_context_tests = {
   },
 
   call_async_to_js_from_worklet_with_error: () => {
-    const callback = Worklets.prepareRunOnJS(() => {
+    const callback = Worklets.createRunOnJS(() => {
       "worklet";
       throw new Error("Test error");
     });
 
-    const workletA = Worklets.defaultContext.prepareRunAsync(() => {
+    const workletA = Worklets.defaultContext.createRunAsync(() => {
       "worklet";
       return callback();
     });
@@ -131,7 +131,7 @@ export const worklet_context_tests = {
       return a + a;
     };
 
-    const w_square = Worklets.defaultContext.prepareRunAsync((a: number) => {
+    const w_square = Worklets.defaultContext.createRunAsync((a: number) => {
       "worklet";
       return Math.sqrt(adder(a));
     });
@@ -146,7 +146,7 @@ export const worklet_context_tests = {
       sharedValue.value = b;
     };
 
-    const workletA = Worklets.defaultContext.prepareRunAsync((a: number) => {
+    const workletA = Worklets.defaultContext.createRunAsync((a: number) => {
       "worklet";
       return workletB(a);
     });
@@ -163,7 +163,7 @@ export const worklet_context_tests = {
       "worklet";
       return 1000;
     };
-    const workletA = Worklets.defaultContext.prepareRunAsync(() => {
+    const workletA = Worklets.defaultContext.createRunAsync(() => {
       "worklet";
       return workletB();
     });
@@ -175,7 +175,7 @@ export const worklet_context_tests = {
       "worklet";
       return 1000;
     };
-    const workletA = Worklets.defaultContext.prepareRunAsync(function () {
+    const workletA = Worklets.defaultContext.createRunAsync(function () {
       "worklet";
       let r = 0;
       for (let i = 0; i < 100; i++) {
@@ -191,7 +191,7 @@ export const worklet_context_tests = {
       "worklet";
       throw Error("Test error");
     };
-    const workletA = Worklets.defaultContext.prepareRunAsync(function () {
+    const workletA = Worklets.defaultContext.createRunAsync(function () {
       "worklet";
       return workletB();
     });
@@ -203,7 +203,7 @@ export const worklet_context_tests = {
       "worklet";
       return a.current;
     };
-    const workletA = Worklets.defaultContext.prepareRunAsync(function () {
+    const workletA = Worklets.defaultContext.createRunAsync(function () {
       "worklet";
       return workletB({ current: 100 });
     });
@@ -212,7 +212,7 @@ export const worklet_context_tests = {
 
   fail_when_calling_a_regular_function_from_a_worklet: () => {
     const func = (a: number) => a;
-    const worklet = Worklets.defaultContext.prepareRunAsync(function () {
+    const worklet = Worklets.defaultContext.createRunAsync(function () {
       "worklet";
       return func(100);
     });
@@ -228,27 +228,27 @@ export const worklet_context_tests = {
       },
     };
     const sharedValue = Worklets.createSharedValue(obj);
-    const worklet = Worklets.defaultContext.prepareRunAsync(function () {
+    const worklet = Worklets.defaultContext.createRunAsync(function () {
       "worklet";
       return sharedValue.value.f();
     });
     return ExpectValue(worklet(), 200);
   },
-  call_prepareRunOnJS_inside_worklet: () => {
+  call_createRunOnJS_inside_worklet: () => {
     const fn = function (b: number) {
       "worklet";
       return b * 2;
     };
     const f = function (a: number) {
       "worklet";
-      const wjs = Worklets.prepareRunOnJS(fn);
+      const wjs = Worklets.createRunOnJS(fn);
       return wjs(a);
     };
-    const w = Worklets.defaultContext.prepareRunAsync(f);
+    const w = Worklets.defaultContext.createRunAsync(f);
     return ExpectValue(w(100), 200);
   },
   call_worklet_in_same_context: () => {
-    const workletInTest = Worklets.defaultContext.prepareRunAsync(function (
+    const workletInTest = Worklets.defaultContext.createRunAsync(function (
       a: number
     ) {
       "worklet";
@@ -256,7 +256,7 @@ export const worklet_context_tests = {
       return 100 + a;
     });
 
-    const worklet = Worklets.defaultContext.prepareRunAsync(function () {
+    const worklet = Worklets.defaultContext.createRunAsync(function () {
       "worklet";
       console.log("ctx: worklet: calling workletInTest(100)");
       const a = workletInTest(100);
@@ -273,21 +273,21 @@ export const worklet_context_tests = {
       return 100 + a;
     }
     calcInCtx.name = "calcInCtx";
-    const workletInCtx = ctx.prepareRunAsync(calcInCtx);
+    const workletInCtx = ctx.createRunAsync(calcInCtx);
 
     function calcInDefaultCtx() {
       "worklet";
       return workletInCtx(100);
     }
     calcInDefaultCtx.name = "calcInDefaultCtx";
-    const worklet = Worklets.defaultContext.prepareRunAsync(calcInDefaultCtx);
+    const worklet = Worklets.defaultContext.createRunAsync(calcInDefaultCtx);
 
     return ExpectValue(worklet(), 200);
   },
-  call_prepareRunAsync_from_context: () => {
-    const worklet = Worklets.defaultContext.prepareRunAsync(() => {
+  call_createRunAsync_from_context: () => {
+    const worklet = Worklets.defaultContext.createRunAsync(() => {
       "worklet";
-      const workletInTest = Worklets.defaultContext.prepareRunAsync(
+      const workletInTest = Worklets.defaultContext.createRunAsync(
         (a: number) => {
           "worklet";
           return 100 + a;
@@ -297,12 +297,12 @@ export const worklet_context_tests = {
     });
     return ExpectValue(worklet(), 200);
   },
-  call_prepareRunAsync_between_contexts: () => {
+  call_createRunAsync_between_contexts: () => {
     const ctx = Worklets.createContext("test");
 
-    const worklet = Worklets.defaultContext.prepareRunAsync(() => {
+    const worklet = Worklets.defaultContext.createRunAsync(() => {
       "worklet";
-      const workletInTest = ctx.prepareRunAsync((a: number) => {
+      const workletInTest = ctx.createRunAsync((a: number) => {
         "worklet";
         return 100 + a;
       });
@@ -315,7 +315,7 @@ export const worklet_context_tests = {
       "worklet";
       return a * 2;
     };
-    let wf: any = Worklets.defaultContext.prepareRunAsync(f);
+    let wf: any = Worklets.defaultContext.createRunAsync(f);
     wf(100);
     wf = undefined;
     return ExpectValue(true, true);
@@ -329,7 +329,7 @@ export const worklet_context_tests = {
       "worklet";
       return f(100);
     };
-    let wf = Worklets.defaultContext.prepareRunAsync(fw);
+    let wf = Worklets.defaultContext.createRunAsync(fw);
     return ExpectValue(wf(), 200);
   },
   call_run_async_directly: () => {
@@ -347,7 +347,7 @@ export const worklet_context_tests = {
         return a * 2;
       });
     };
-    const w = Worklets.defaultContext.prepareRunAsync(f);
+    const w = Worklets.defaultContext.createRunAsync(f);
     return ExpectValue(w(100), 200);
   },
   call_run_async_and_run_on_js_directly: () => {

--- a/example/Tests/worklet-context-tests.ts
+++ b/example/Tests/worklet-context-tests.ts
@@ -24,7 +24,7 @@ export const worklet_context_tests = {
       "worklet";
       return a + x;
     };
-    const w = Worklets.createRunInContextFn(f);
+    const w = Worklets.defaultContext.prepareRunAsync(f);
     return ExpectValue(w(100), 200);
   },
 
@@ -34,7 +34,7 @@ export const worklet_context_tests = {
       "worklet";
       return a;
     };
-    const w = Worklets.createRunInContextFn(f, context);
+    const w = context.prepareRunAsync(f);
     return ExpectValue(w(100), 100);
   },
 
@@ -43,7 +43,7 @@ export const worklet_context_tests = {
       "worklet";
       throw new Error("Test error");
     };
-    const w = Worklets.createRunInContextFn(f);
+    const w = Worklets.defaultContext.prepareRunAsync(f);
     return ExpectException(w, "Test error");
   },
 
@@ -53,7 +53,7 @@ export const worklet_context_tests = {
       "worklet";
       throw new Error("Test error");
     };
-    const w = Worklets.createRunInContextFn(f, context);
+    const w = context.prepareRunAsync(f);
     return ExpectException(w, "Test error");
   },
 
@@ -69,7 +69,7 @@ export const worklet_context_tests = {
       workletB(a);
     };
 
-    const w = Worklets.createRunInContextFn(workletA);
+    const w = Worklets.defaultContext.prepareRunAsync(workletA);
     return Expect(w(100), () => {
       return sharedValue.value === 100
         ? undefined
@@ -84,14 +84,14 @@ export const worklet_context_tests = {
       sharedValue.value = a;
     };
 
-    const js1 = Worklets.createRunInJsFn(setSharedValue);
+    const js1 = Worklets.prepareRunOnJS(setSharedValue);
 
     const w1 = function (a: number) {
       "worklet";
       return js1(a);
     };
 
-    const w = Worklets.createRunInContextFn(w1);
+    const w = Worklets.defaultContext.prepareRunAsync(w1);
     return Expect(w(100), () => {
       return sharedValue.value === 100
         ? undefined
@@ -100,12 +100,12 @@ export const worklet_context_tests = {
   },
 
   call_async_to_js_from_worklet_with_retval: () => {
-    const workletB = Worklets.createRunInJsFn(function (a: number) {
+    const workletB = Worklets.prepareRunOnJS(function (a: number) {
       "worklet";
       return a;
     });
 
-    const workletA = Worklets.createRunInContextFn(function (a: number) {
+    const workletA = Worklets.defaultContext.prepareRunAsync((a: number) => {
       "worklet";
       return workletB(a);
     });
@@ -113,12 +113,12 @@ export const worklet_context_tests = {
   },
 
   call_async_to_js_from_worklet_with_error: () => {
-    const callback = Worklets.createRunInJsFn(() => {
+    const callback = Worklets.prepareRunOnJS(() => {
       "worklet";
       throw new Error("Test error");
     });
 
-    const workletA = Worklets.createRunInContextFn(function () {
+    const workletA = Worklets.defaultContext.prepareRunAsync(() => {
       "worklet";
       return callback();
     });
@@ -131,7 +131,7 @@ export const worklet_context_tests = {
       return a + a;
     };
 
-    const w_square = Worklets.createRunInContextFn(function (a: number) {
+    const w_square = Worklets.defaultContext.prepareRunAsync((a: number) => {
       "worklet";
       return Math.sqrt(adder(a));
     });
@@ -146,7 +146,7 @@ export const worklet_context_tests = {
       sharedValue.value = b;
     };
 
-    const workletA = Worklets.createRunInContextFn(function (a: number) {
+    const workletA = Worklets.defaultContext.prepareRunAsync((a: number) => {
       "worklet";
       return workletB(a);
     });
@@ -163,7 +163,7 @@ export const worklet_context_tests = {
       "worklet";
       return 1000;
     };
-    const workletA = Worklets.createRunInContextFn(function () {
+    const workletA = Worklets.defaultContext.prepareRunAsync(() => {
       "worklet";
       return workletB();
     });
@@ -175,7 +175,7 @@ export const worklet_context_tests = {
       "worklet";
       return 1000;
     };
-    const workletA = Worklets.createRunInContextFn(function () {
+    const workletA = Worklets.defaultContext.prepareRunAsync(function () {
       "worklet";
       let r = 0;
       for (let i = 0; i < 100; i++) {
@@ -191,7 +191,7 @@ export const worklet_context_tests = {
       "worklet";
       throw Error("Test error");
     };
-    const workletA = Worklets.createRunInContextFn(function () {
+    const workletA = Worklets.defaultContext.prepareRunAsync(function () {
       "worklet";
       return workletB();
     });
@@ -203,7 +203,7 @@ export const worklet_context_tests = {
       "worklet";
       return a.current;
     };
-    const workletA = Worklets.createRunInContextFn(function () {
+    const workletA = Worklets.defaultContext.prepareRunAsync(function () {
       "worklet";
       return workletB({ current: 100 });
     });
@@ -212,7 +212,7 @@ export const worklet_context_tests = {
 
   fail_when_calling_a_regular_function_from_a_worklet: () => {
     const func = (a: number) => a;
-    const worklet = Worklets.createRunInContextFn(function () {
+    const worklet = Worklets.defaultContext.prepareRunAsync(function () {
       "worklet";
       return func(100);
     });
@@ -228,33 +228,35 @@ export const worklet_context_tests = {
       },
     };
     const sharedValue = Worklets.createSharedValue(obj);
-    const worklet = Worklets.createRunInContextFn(function () {
+    const worklet = Worklets.defaultContext.prepareRunAsync(function () {
       "worklet";
       return sharedValue.value.f();
     });
     return ExpectValue(worklet(), 200);
   },
-  call_createRunInJsFn_inside_worklet: () => {
+  call_prepareRunOnJS_inside_worklet: () => {
     const fn = function (b: number) {
       "worklet";
       return b * 2;
     };
     const f = function (a: number) {
       "worklet";
-      const wjs = Worklets.createRunInJsFn(fn);
+      const wjs = Worklets.prepareRunOnJS(fn);
       return wjs(a);
     };
-    const w = Worklets.createRunInContextFn(f);
+    const w = Worklets.defaultContext.prepareRunAsync(f);
     return ExpectValue(w(100), 200);
   },
   call_worklet_in_same_context: () => {
-    const workletInTest = Worklets.createRunInContextFn(function (a: number) {
+    const workletInTest = Worklets.defaultContext.prepareRunAsync(function (
+      a: number
+    ) {
       "worklet";
       console.log("ctx: workletInTest: returning 100 + ", a);
       return 100 + a;
     });
 
-    const worklet = Worklets.createRunInContextFn(function () {
+    const worklet = Worklets.defaultContext.prepareRunAsync(function () {
       "worklet";
       console.log("ctx: worklet: calling workletInTest(100)");
       const a = workletInTest(100);
@@ -271,37 +273,39 @@ export const worklet_context_tests = {
       return 100 + a;
     }
     calcInCtx.name = "calcInCtx";
-    const workletInCtx = Worklets.createRunInContextFn(calcInCtx, ctx);
+    const workletInCtx = ctx.prepareRunAsync(calcInCtx);
 
     function calcInDefaultCtx() {
       "worklet";
       return workletInCtx(100);
     }
     calcInDefaultCtx.name = "calcInDefaultCtx";
-    const worklet = Worklets.createRunInContextFn(calcInDefaultCtx);
+    const worklet = Worklets.defaultContext.prepareRunAsync(calcInDefaultCtx);
 
     return ExpectValue(worklet(), 200);
   },
-  call_createRunInContextFn_from_context: () => {
-    const worklet = Worklets.createRunInContextFn(function () {
+  call_prepareRunAsync_from_context: () => {
+    const worklet = Worklets.defaultContext.prepareRunAsync(() => {
       "worklet";
-      const workletInTest = Worklets.createRunInContextFn(function (a: number) {
-        "worklet";
-        return 100 + a;
-      });
+      const workletInTest = Worklets.defaultContext.prepareRunAsync(
+        (a: number) => {
+          "worklet";
+          return 100 + a;
+        }
+      );
       return workletInTest(100);
     });
     return ExpectValue(worklet(), 200);
   },
-  call_createRunInContextFn_between_contexts: () => {
+  call_prepareRunAsync_between_contexts: () => {
     const ctx = Worklets.createContext("test");
 
-    const worklet = Worklets.createRunInContextFn(function () {
+    const worklet = Worklets.defaultContext.prepareRunAsync(() => {
       "worklet";
-      const workletInTest = Worklets.createRunInContextFn(function (a: number) {
+      const workletInTest = ctx.prepareRunAsync((a: number) => {
         "worklet";
         return 100 + a;
-      }, ctx);
+      });
       return workletInTest(100);
     });
     return ExpectValue(worklet(), 200);
@@ -311,7 +315,7 @@ export const worklet_context_tests = {
       "worklet";
       return a * 2;
     };
-    let wf: any = Worklets.createRunInContextFn(f);
+    let wf: any = Worklets.defaultContext.prepareRunAsync(f);
     wf(100);
     wf = undefined;
     return ExpectValue(true, true);
@@ -325,7 +329,54 @@ export const worklet_context_tests = {
       "worklet";
       return f(100);
     };
-    let wf = Worklets.createRunInContextFn(fw);
+    let wf = Worklets.defaultContext.prepareRunAsync(fw);
     return ExpectValue(wf(), 200);
+  },
+  call_run_async_directly: () => {
+    const result = Worklets.defaultContext.runAsync(() => {
+      "worklet";
+      return 42;
+    });
+    return ExpectValue(result, 42);
+  },
+  call_run_on_js_directly: () => {
+    const f = function (a: number) {
+      "worklet";
+      return Worklets.runOnJS(() => {
+        "worklet";
+        return a * 2;
+      });
+    };
+    const w = Worklets.defaultContext.prepareRunAsync(f);
+    return ExpectValue(w(100), 200);
+  },
+  call_run_async_and_run_on_js_directly: () => {
+    const a = 150;
+    const result = Worklets.defaultContext.runAsync(() => {
+      "worklet";
+      const b = a * 2;
+      return Worklets.runOnJS(() => {
+        "worklet";
+        return b * 2;
+      });
+    });
+    return ExpectValue(result, 600);
+  },
+  call_run_async_and_run_on_js_directly_other_context: () => {
+    const a = 150;
+    const context = Worklets.createContext("nested-context");
+    const result = Worklets.defaultContext.runAsync(() => {
+      "worklet";
+      const b = a * 2;
+      return context.runAsync(() => {
+        "worklet";
+        const c = b * 2;
+        return Worklets.runOnJS(() => {
+          "worklet";
+          return c * 2;
+        });
+      });
+    });
+    return ExpectValue(result, 1200);
   },
 };

--- a/example/Tests/worklet-tests.ts
+++ b/example/Tests/worklet-tests.ts
@@ -3,7 +3,7 @@ import { ExpectException, ExpectValue, getWorkletInfo } from "./utils";
 
 export const worklet_tests = {
   check_is_not_worklet: () => {
-    const fn = Worklets.defaultContext.prepareRunAsync((a: number) => {
+    const fn = Worklets.defaultContext.createRunAsync((a: number) => {
       return a * 200;
     });
     return ExpectValue(typeof fn, "function");
@@ -26,14 +26,14 @@ export const worklet_tests = {
         return c + cl.x;
       };
       const nestedWorkletFn =
-        Worklets.defaultContext.prepareRunAsync(nestedWorklet);
+        Worklets.defaultContext.createRunAsync(nestedWorklet);
       return nestedWorkletFn(100);
     };
     const fw = () => {
       "worklet";
       return rootWorklet();
     };
-    let wf = Worklets.defaultContext.prepareRunAsync(fw);
+    let wf = Worklets.defaultContext.createRunAsync(fw);
     return ExpectValue(wf(), 200);
   },
   check_worklet_closure_shared_value: () => {
@@ -61,7 +61,7 @@ export const worklet_tests = {
       "worklet";
       return api.someFunc(100);
     };
-    const w = Worklets.defaultContext.prepareRunAsync(f);
+    const w = Worklets.defaultContext.createRunAsync(f);
     return ExpectException(w);
   },
   check_js_promise_resolves: () => {
@@ -76,7 +76,7 @@ export const worklet_tests = {
       "worklet";
       return a + 100;
     };
-    const w = Worklets.defaultContext.prepareRunAsync(f);
+    const w = Worklets.defaultContext.createRunAsync(f);
     return ExpectValue(
       new Promise((resolve) => {
         w(100).then(resolve);
@@ -89,7 +89,7 @@ export const worklet_tests = {
       "worklet";
       return a + 100;
     };
-    const w = Worklets.defaultContext.prepareRunAsync(f);
+    const w = Worklets.defaultContext.createRunAsync(f);
     return ExpectValue(
       new Promise<void>((resolve) => {
         w(100).finally(resolve);
@@ -102,7 +102,7 @@ export const worklet_tests = {
       "worklet";
       return a + 100;
     };
-    const w = Worklets.defaultContext.prepareRunAsync(f);
+    const w = Worklets.defaultContext.createRunAsync(f);
     return ExpectValue(
       new Promise<void>((resolve) => {
         w(100).then().finally(resolve);
@@ -116,7 +116,7 @@ export const worklet_tests = {
       "worklet";
       return Array.isArray(array);
     };
-    const w = Worklets.defaultContext.prepareRunAsync(f);
+    const w = Worklets.defaultContext.createRunAsync(f);
     return ExpectValue(w(), true);
   },
   check_pure_array_is_passed_as_jsi_array: () => {
@@ -125,7 +125,7 @@ export const worklet_tests = {
       "worklet";
       return Worklets.__jsi_is_array(array);
     };
-    const w = Worklets.defaultContext.prepareRunAsync(f);
+    const w = Worklets.defaultContext.createRunAsync(f);
     return ExpectValue(w(), true);
   },
   check_pure_array_inside_object_is_passed_as_jsi_array: () => {
@@ -134,7 +134,7 @@ export const worklet_tests = {
       "worklet";
       return Worklets.__jsi_is_array(obj.a);
     };
-    const w = Worklets.defaultContext.prepareRunAsync(f);
+    const w = Worklets.defaultContext.createRunAsync(f);
     return ExpectValue(w(), true);
   },
   check_pure_array_nested_argument_is_passed_as_jsi_array: () => {
@@ -143,7 +143,7 @@ export const worklet_tests = {
       "worklet";
       return Worklets.__jsi_is_array(t.a);
     };
-    const w = Worklets.defaultContext.prepareRunAsync(f);
+    const w = Worklets.defaultContext.createRunAsync(f);
     return ExpectValue(w(obj), true);
   },
   check_shared_value_array_is_not_passed_as_jsi_array: () => {
@@ -152,7 +152,7 @@ export const worklet_tests = {
       "worklet";
       return Worklets.__jsi_is_array(obj.value);
     };
-    const w = Worklets.defaultContext.prepareRunAsync(f);
+    const w = Worklets.defaultContext.createRunAsync(f);
     return ExpectValue(w(), false);
   },
   check_shared_value_nested_array_is_not_passed_as_jsi_array: () => {
@@ -161,7 +161,7 @@ export const worklet_tests = {
       "worklet";
       return Worklets.__jsi_is_array(obj.value.a);
     };
-    const w = Worklets.defaultContext.prepareRunAsync(f);
+    const w = Worklets.defaultContext.createRunAsync(f);
     return ExpectValue(w(), false);
   },
   check_called_directly: () => {

--- a/example/Tests/worklet-tests.ts
+++ b/example/Tests/worklet-tests.ts
@@ -3,7 +3,7 @@ import { ExpectException, ExpectValue, getWorkletInfo } from "./utils";
 
 export const worklet_tests = {
   check_is_not_worklet: () => {
-    const fn = Worklets.createRunInContextFn((a: number) => {
+    const fn = Worklets.defaultContext.prepareRunAsync((a: number) => {
       return a * 200;
     });
     return ExpectValue(typeof fn, "function");
@@ -25,14 +25,15 @@ export const worklet_tests = {
         "worklet";
         return c + cl.x;
       };
-      const nestedWorkletFn = Worklets.createRunInContextFn(nestedWorklet);
+      const nestedWorkletFn =
+        Worklets.defaultContext.prepareRunAsync(nestedWorklet);
       return nestedWorkletFn(100);
     };
     const fw = () => {
       "worklet";
       return rootWorklet();
     };
-    let wf = Worklets.createRunInContextFn(fw);
+    let wf = Worklets.defaultContext.prepareRunAsync(fw);
     return ExpectValue(wf(), 200);
   },
   check_worklet_closure_shared_value: () => {
@@ -60,7 +61,7 @@ export const worklet_tests = {
       "worklet";
       return api.someFunc(100);
     };
-    const w = Worklets.createRunInContextFn(f);
+    const w = Worklets.defaultContext.prepareRunAsync(f);
     return ExpectException(w);
   },
   check_js_promise_resolves: () => {
@@ -75,7 +76,7 @@ export const worklet_tests = {
       "worklet";
       return a + 100;
     };
-    const w = Worklets.createRunInContextFn(f);
+    const w = Worklets.defaultContext.prepareRunAsync(f);
     return ExpectValue(
       new Promise((resolve) => {
         w(100).then(resolve);
@@ -88,7 +89,7 @@ export const worklet_tests = {
       "worklet";
       return a + 100;
     };
-    const w = Worklets.createRunInContextFn(f);
+    const w = Worklets.defaultContext.prepareRunAsync(f);
     return ExpectValue(
       new Promise<void>((resolve) => {
         w(100).finally(resolve);
@@ -101,7 +102,7 @@ export const worklet_tests = {
       "worklet";
       return a + 100;
     };
-    const w = Worklets.createRunInContextFn(f);
+    const w = Worklets.defaultContext.prepareRunAsync(f);
     return ExpectValue(
       new Promise<void>((resolve) => {
         w(100).then().finally(resolve);
@@ -115,7 +116,7 @@ export const worklet_tests = {
       "worklet";
       return Array.isArray(array);
     };
-    const w = Worklets.createRunInContextFn(f);
+    const w = Worklets.defaultContext.prepareRunAsync(f);
     return ExpectValue(w(), true);
   },
   check_pure_array_is_passed_as_jsi_array: () => {
@@ -124,7 +125,7 @@ export const worklet_tests = {
       "worklet";
       return Worklets.__jsi_is_array(array);
     };
-    const w = Worklets.createRunInContextFn(f);
+    const w = Worklets.defaultContext.prepareRunAsync(f);
     return ExpectValue(w(), true);
   },
   check_pure_array_inside_object_is_passed_as_jsi_array: () => {
@@ -133,7 +134,7 @@ export const worklet_tests = {
       "worklet";
       return Worklets.__jsi_is_array(obj.a);
     };
-    const w = Worklets.createRunInContextFn(f);
+    const w = Worklets.defaultContext.prepareRunAsync(f);
     return ExpectValue(w(), true);
   },
   check_pure_array_nested_argument_is_passed_as_jsi_array: () => {
@@ -142,7 +143,7 @@ export const worklet_tests = {
       "worklet";
       return Worklets.__jsi_is_array(t.a);
     };
-    const w = Worklets.createRunInContextFn(f);
+    const w = Worklets.defaultContext.prepareRunAsync(f);
     return ExpectValue(w(obj), true);
   },
   check_shared_value_array_is_not_passed_as_jsi_array: () => {
@@ -151,7 +152,7 @@ export const worklet_tests = {
       "worklet";
       return Worklets.__jsi_is_array(obj.value);
     };
-    const w = Worklets.createRunInContextFn(f);
+    const w = Worklets.defaultContext.prepareRunAsync(f);
     return ExpectValue(w(), false);
   },
   check_shared_value_nested_array_is_not_passed_as_jsi_array: () => {
@@ -160,7 +161,14 @@ export const worklet_tests = {
       "worklet";
       return Worklets.__jsi_is_array(obj.value.a);
     };
-    const w = Worklets.createRunInContextFn(f);
+    const w = Worklets.defaultContext.prepareRunAsync(f);
     return ExpectValue(w(), false);
+  },
+  check_called_directly: () => {
+    const result = Worklets.defaultContext.runAsync(() => {
+      "worklet";
+      return 42;
+    });
+    return ExpectValue(result, 42);
   },
 };

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -266,7 +266,7 @@ PODS:
   - React-jsinspector (0.71.2)
   - React-logger (0.71.2):
     - glog
-  - react-native-worklets-core (1.0.0-beta.1):
+  - react-native-worklets-core (1.0.0-beta.2):
     - React
     - React-callinvoker
     - React-Core
@@ -495,7 +495,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: c7e028406112db456ac3cf5720d266bc7bc20938
   React-jsinspector: ea8101acf525ec08b2d87ddf0637d45f8e3b4148
   React-logger: 97987f46779d8dd24656474ad0c43a5b459f31d6
-  react-native-worklets-core: b212332df75d3154357bd9833730e540d4e94b50
+  react-native-worklets-core: 81033d42d22985176f9d1ef97378df02c092232e
   React-perflogger: c7ccda3d1d1da837f7ff4e54e816022a6803ee87
   React-RCTActionSheet: 01c125aebbad462a24228f68c584c7a921d6c28e
   React-RCTAnimation: 5277a9440acffc4a5b7baa6ae3880fe467277ae6

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -266,7 +266,7 @@ PODS:
   - React-jsinspector (0.71.2)
   - React-logger (0.71.2):
     - glog
-  - react-native-worklets-core (0.5.0):
+  - react-native-worklets-core (1.0.0-beta.0):
     - React
     - React-callinvoker
     - React-Core
@@ -495,7 +495,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: c7e028406112db456ac3cf5720d266bc7bc20938
   React-jsinspector: ea8101acf525ec08b2d87ddf0637d45f8e3b4148
   React-logger: 97987f46779d8dd24656474ad0c43a5b459f31d6
-  react-native-worklets-core: ba5a1d4f91be4edd8cf09537a9b8fa46a7f70436
+  react-native-worklets-core: 9f98e03bcdcde5cac3b0036ccf4c60c90c060287
   React-perflogger: c7ccda3d1d1da837f7ff4e54e816022a6803ee87
   React-RCTActionSheet: 01c125aebbad462a24228f68c584c7a921d6c28e
   React-RCTAnimation: 5277a9440acffc4a5b7baa6ae3880fe467277ae6

--- a/example/package.json
+++ b/example/package.json
@@ -18,6 +18,7 @@
     "@babel/runtime": "^7.20.0",
     "babel-plugin-module-resolver": "^5.0.0",
     "metro-react-native-babel-preset": "0.73.7",
+    "pod-install": "^0.2.0",
     "react-native-worklets-core": "link:../"
   },
   "jest": {

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -3495,6 +3495,11 @@ pkg-up@^3.1.0:
   dependencies:
     find-up "^3.0.0"
 
+pod-install@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/pod-install/-/pod-install-0.2.0.tgz#11f87e919f83bbd4deaa159aa5ce2f617ee0ff9d"
+  integrity sha512-NxNEq5OpIFn0UjS9hznBNDMvQw2+3diEegChIr2Zv2XlWaNRcOoUp6Kc2zrD372C49QXoZRwzc0Aqf6605Ftjg==
+
 posix-character-classes@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"

--- a/src/hooks/useRunInJS.ts
+++ b/src/hooks/useRunInJS.ts
@@ -13,7 +13,7 @@ export function useRunInJS<T extends (...args: any[]) => any>(
   dependencyList: DependencyList
 ): (...args: Parameters<T>) => Promise<ReturnType<T>> {
   const worklet = useMemo(
-    () => Worklets.createRunInJsFn(callback),
+    () => Worklets.prepareRunOnJS(callback),
     // eslint-disable-next-line react-hooks/exhaustive-deps
     dependencyList
   );

--- a/src/hooks/useRunInJS.ts
+++ b/src/hooks/useRunInJS.ts
@@ -13,7 +13,7 @@ export function useRunInJS<T extends (...args: any[]) => any>(
   dependencyList: DependencyList
 ): (...args: Parameters<T>) => Promise<ReturnType<T>> {
   const worklet = useMemo(
-    () => Worklets.prepareRunOnJS(callback),
+    () => Worklets.createRunOnJS(callback),
     // eslint-disable-next-line react-hooks/exhaustive-deps
     dependencyList
   );

--- a/src/hooks/useWorklet.ts
+++ b/src/hooks/useWorklet.ts
@@ -19,9 +19,9 @@ export function useWorklet<T extends (...args: any[]) => any>(
   const worklet = useMemo(
     () => {
       if (context === "default") {
-        return Worklets.defaultContext.prepareRunAsync(callback);
+        return Worklets.defaultContext.createRunAsync(callback);
       } else {
-        return context.prepareRunAsync(callback);
+        return context.createRunAsync(callback);
       }
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/hooks/useWorklet.ts
+++ b/src/hooks/useWorklet.ts
@@ -5,6 +5,7 @@ import type { IWorkletContext } from "src/types";
  * Create a Worklet function that persists between re-renders.
  * The returned function can be called from both a Worklet context and the JS context, but will execute on a Worklet context.
  *
+ * @worklet
  * @param context The context to run this Worklet in. Can be `default` to use the default background context, or a custom context.
  * @param callback The Worklet. Must be marked with the `'worklet'` directive.
  * @param dependencyList The React dependencies of this Worklet.
@@ -18,9 +19,9 @@ export function useWorklet<T extends (...args: any[]) => any>(
   const worklet = useMemo(
     () => {
       if (context === "default") {
-        return Worklets.createRunInContextFn(callback);
+        return Worklets.defaultContext.prepareRunAsync(callback);
       } else {
-        return Worklets.createRunInContextFn(callback, context);
+        return context.prepareRunAsync(callback);
       }
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,10 @@
+/**
+ * Represents a value that can be shared between multiple contexts.
+ *
+ * Getting and setting the `value` is thread-safe.
+ *
+ * Objects and Arrays are wrapped as custom C++ Proxies instead of copied by value.
+ */
 export interface ISharedValue<T> {
   get value(): T;
   set value(v: T);
@@ -28,6 +35,36 @@ export interface IWorkletContext {
    * @param propertyObject
    */
   addDecorator: <T>(propertyName: string, propertyObject: T) => void;
+  /**
+   * Creates a function that can be executed asynchronously on the Worklet context.
+   *
+   * The resulting function is memoized, so this is merely just a bit more efficient than {@linkcode runAsync}.
+   * @worklet
+   * @param worklet The worklet to run on this Context. It needs to be decorated with the `'worklet'` directive.
+   * @returns A function that can be called to execute the Worklet function on this context.
+   * @example
+   * ```ts
+   * const context = Worklets.createContext("myContext")
+   * const func = context.prepareRunAsync((name) => `hello ${name}!`)
+   * const first = await func("marc")
+   * const second = await func("christian")
+   * ```
+   */
+  prepareRunAsync: <TArgs, TReturn>(
+    worklet: (...args: TArgs[]) => TReturn
+  ) => (...args: TArgs[]) => Promise<TReturn>;
+  /**
+   * Runs the given Function asynchronously on this Worklet context.
+   * @worklet
+   * @param worklet The worklet to run on this Context. It needs to be decorated with the `'worklet'` directive.
+   * @returns A Promise that resolves once the Worklet function has completed executing.
+   * @example
+   * ```ts
+   * const context = Worklets.createContext("myContext")
+   * const string = await context.runAsync(() => "hello!")
+   * ```
+   */
+  runAsync: <T>(worklet: () => T) => Promise<T>;
 }
 
 export type ContextType = {
@@ -54,33 +91,50 @@ export interface IWorkletNativeApi {
    */
   createContext: (name: string) => IWorkletContext;
   /**
-   * Creates a value that can be shared between runtimes
+   * Creates a value that can be shared between runtimes.
+   *
+   * Arrays and Objects are wrapped in C++ Proxies instead of copied by value.
+   * Array and Objects reads and writes are thread-safe.
    */
   createSharedValue: <T>(value: T) => ISharedValue<T>;
+
   /**
-   * Creates a function that will be executed in the worklet context. The function
-   * will return a promise that will be resolved when the function has been
-   * executed on the worklet thread.
+   * Creates a function that can be executed asynchronously on the default React-JS context.
    *
-   * Used to create a function to call from the JS thread to the worklet thread.
-   * @param worklet Decorated function that will be called in the context
-   * @param context Context to call function in, or default context if not set.
-   * @returns A function that will be called in the worklet context
+   * The resulting function is memoized, so this is merely just a bit more efficient than {@linkcode runOnJS}.
+   * @param func The function to run on the default React-JS context.
+   * @returns A function that can be called to execute the function on the default React-JS .
+   * @example
+   * ```ts
+   * const [user, setUser] = useState("marc")
+   *
+   * const context = Worklets.defaultContext
+   * const callback = Worklets.prepareRunOnJS(setUser)
+   * context.runAsync(() => {
+   *   const name = "christian"
+   *   callback(name)
+   * })
+   * ```
    */
-  createRunInContextFn: <C extends ContextType, T, A extends Array<unknown>>(
-    fn: (this: C, ...args: A) => T,
-    context?: IWorkletContext
-  ) => (...args: A) => Promise<T>;
+  prepareRunOnJS: <TArgs, TReturn>(
+    func: (...args: TArgs[]) => TReturn
+  ) => (...args: TArgs[]) => Promise<TReturn>;
   /**
-   * Creates a function that will be executed in the javascript context.
+   * Runs the given Function asynchronously on the default React-JS context.
+   * @param func The function to run on the default React-JS context.
+   * @returns A Promise that resolves once the function has completed executing.
+   * @example
+   * ```ts
+   * const [user, setUser] = useState("marc")
    *
-   * Used to create a function to call back to the JS context from a worklet context.
-   * @param worklet Decorated function that will be called in the JS context
-   * @returns A function that will be called in the JS context
+   * const context = Worklets.defaultContext
+   * context.runAsync(() => {
+   *   const name = "christian"
+   *   Worklets.runOnJS(() => setUser(name))
+   * })
+   * ```
    */
-  createRunInJsFn: <C extends ContextType, T, A extends Array<unknown>>(
-    fn: (this: C, ...args: A) => T
-  ) => (...args: A) => Promise<T>;
+  runOnJS: <T>(func: () => T) => Promise<T>;
 
   /**
    * Get the default Worklet context.

--- a/src/types.ts
+++ b/src/types.ts
@@ -45,12 +45,12 @@ export interface IWorkletContext {
    * @example
    * ```ts
    * const context = Worklets.createContext("myContext")
-   * const func = context.prepareRunAsync((name) => `hello ${name}!`)
+   * const func = context.createRunAsync((name) => `hello ${name}!`)
    * const first = await func("marc")
    * const second = await func("christian")
    * ```
    */
-  prepareRunAsync: <TArgs, TReturn>(
+  createRunAsync: <TArgs, TReturn>(
     worklet: (...args: TArgs[]) => TReturn
   ) => (...args: TArgs[]) => Promise<TReturn>;
   /**
@@ -109,14 +109,14 @@ export interface IWorkletNativeApi {
    * const [user, setUser] = useState("marc")
    *
    * const context = Worklets.defaultContext
-   * const callback = Worklets.prepareRunOnJS(setUser)
+   * const callback = Worklets.createRunOnJS(setUser)
    * context.runAsync(() => {
    *   const name = "christian"
    *   callback(name)
    * })
    * ```
    */
-  prepareRunOnJS: <TArgs, TReturn>(
+  createRunOnJS: <TArgs, TReturn>(
     func: (...args: TArgs[]) => TReturn
   ) => (...args: TArgs[]) => Promise<TReturn>;
   /**


### PR DESCRIPTION
Simplifies the API of RN Worklets Core.

1. `Worklets.createRunInContextFn(func, context)` has been renamed to `context.prepareRunAsync(func)`
  1. `context.runAsync(func)` has been added for convenience
2.`Worklets.createRunInJsFn(func)` has been renamed to `Worklets.prepareRunOnJS(func)`
  1. `Worklets.runOnJS(func)` has been added for convenience 

Since `runAsync` is now bound to a Worklet context, to run something on the default context you would now do:

```ts
Worklets.defaultContext.runAsync(() => {
  'worklet'
  console.log("hi!")
})
```

This new API has two benefits:

1. It is better to read and better organized, since those methods are specific to the contexts you create. This is aligned with how native Threads work as well.
2. It is less likely to make mistakes:
  1. Forgetting the `context` parameter is no longer an issue. Previously it could happen that a Worklet ran on the wrong Thread because the user missed the optional context parameter and it executed on the default context.
  2. Forgetting the tailing `()` to actually call the Worklet is now less likely to happen since we have convenience methods (`runAsync` and `runOnJS`)