### PR TITLE
fix: Fix reload crash by also listening to Main JS Runtime in `RuntimeAwareCache`

### DIFF
--- a/cpp/WKTJsiWorkletContext.cpp
+++ b/cpp/WKTJsiWorkletContext.cpp
@@ -72,9 +72,6 @@ void JsiWorkletContext::initialize(
     std::function<void(std::function<void()> &&)> jsCallInvoker,
     std::function<void(std::function<void()> &&)> workletCallInvoker) {
 
-  // Register main runtime
-  BaseRuntimeAwareCache::setMainJsRuntime(jsRuntime);
-
   _name = name;
   _jsRuntime = jsRuntime;
   _jsCallInvoker = jsCallInvoker;

--- a/cpp/base/WKTRuntimeAwareCache.cpp
+++ b/cpp/base/WKTRuntimeAwareCache.cpp
@@ -1,7 +1,3 @@
 #include "WKTRuntimeAwareCache.h"
 
-namespace RNWorklet {
-
-jsi::Runtime *BaseRuntimeAwareCache::_mainRuntime = nullptr;
-
-} // namespace RNWorklet
+namespace RNWorklet {} // namespace RNWorklet

--- a/cpp/base/WKTRuntimeAwareCache.cpp
+++ b/cpp/base/WKTRuntimeAwareCache.cpp
@@ -1,3 +1,0 @@
-#include "WKTRuntimeAwareCache.h"
-
-namespace RNWorklet {} // namespace RNWorklet

--- a/cpp/base/WKTRuntimeAwareCache.h
+++ b/cpp/base/WKTRuntimeAwareCache.h
@@ -21,17 +21,6 @@ namespace jsi = facebook::jsi;
  * eventually) will result in a crash (JSI objects keep a pointer to memory
  * managed by the runtime, accessing that portion of the memory after runtime is
  * deleted is the root cause of that crash).
- *
- * In order to provide an efficient implementation that does not add an overhead
- * for the cases when only a single runtiome is used, which is the primary
- * usecase, the following assumption has been made: Only for secondary runtimes
- * we track destruction and clean up the store associated with that runtime. For
- * the first runtime we assume that the object holding the store is destroyed
- * prior to the destruction of that runtime.
- *
- * The above assumption makes it work without any overhead when only single
- * runtime is in use. Specifically, we don't perform any additional operations
- * related to tracking runtime lifecycle when only a single runtime is used.
  */
 template <typename T>
 class RuntimeAwareCache : public RuntimeLifecycleListener {
@@ -45,7 +34,7 @@ public:
   ~RuntimeAwareCache() {
     for (auto &cache : _runtimeCaches) {
       // remove all `onRuntimeDestroyed` listeners.
-      RuntimeLifecycleMonitor::removeListener(cache.first, this);
+      RuntimeLifecycleMonitor::removeListener(*cache.first, this);
     }
   }
 

--- a/cpp/base/WKTRuntimeAwareCache.h
+++ b/cpp/base/WKTRuntimeAwareCache.h
@@ -12,23 +12,6 @@ namespace RNWorklet {
 
 namespace jsi = facebook::jsi;
 
-class BaseRuntimeAwareCache {
-public:
-  static void setMainJsRuntime(jsi::Runtime *rt) { _mainRuntime = rt; }
-
-protected:
-  static jsi::Runtime *getMainJsRuntime() {
-    assert(_mainRuntime != nullptr &&
-           "Expected main Javascript runtime to be set in the "
-           "BaseRuntimeAwareCache class.");
-
-    return _mainRuntime;
-  }
-
-private:
-  static jsi::Runtime *_mainRuntime;
-};
-
 /**
  * Provides a way to keep data specific to a jsi::Runtime instance that gets
  * cleaned up when that runtime is destroyed. This is necessary because JSI does
@@ -51,51 +34,36 @@ private:
  * related to tracking runtime lifecycle when only a single runtime is used.
  */
 template <typename T>
-class RuntimeAwareCache : public BaseRuntimeAwareCache,
-                          public RuntimeLifecycleListener {
+class RuntimeAwareCache : public RuntimeLifecycleListener {
 
 public:
   void onRuntimeDestroyed(jsi::Runtime *rt) override {
-    if (getMainJsRuntime() != rt) {
-      // We are removing a secondary runtime
-      _secondaryRuntimeCaches.erase(rt);
-    }
+    // A runtime has been destroyed, so destroy the related cache.
+    _runtimeCaches.erase(rt);
   }
 
   ~RuntimeAwareCache() {
-    for (auto &cache : _secondaryRuntimeCaches) {
-      RuntimeLifecycleMonitor::removeListener(
-          *static_cast<jsi::Runtime *>(cache.first), this);
+    for (auto &cache : _runtimeCaches) {
+      // remove all `onRuntimeDestroyed` listeners.
+      RuntimeLifecycleMonitor::removeListener(cache.first, this);
     }
   }
 
   T &get(jsi::Runtime &rt) {
-    // We check if we're accessing the main runtime - this is the happy path
-    // to avoid us having to lookup by runtime for caches that only has a single
-    // runtime
-    if (getMainJsRuntime() == &rt) {
-      return _primaryCache;
-    } else {
-      if (_secondaryRuntimeCaches.count(&rt) == 0) {
-        // we only add listener when the secondary runtime is used, this assumes
-        // that the secondary runtime is terminated first. This lets us avoid
-        // additional complexity for the majority of cases when objects are not
-        // shared between runtimes. Otherwise we'd have to register all objects
-        // with the RuntimeMonitor as opposed to only registering ones that are
-        // used in secondary runtime. Note that we can't register listener here
-        // with the primary runtime as it may run on a separate thread.
-        RuntimeLifecycleMonitor::addListener(rt, this);
+    if (_runtimeCaches.count(&rt) == 0) {
+      // This is the first time this Runtime has been accessed,
+      // set up a `onRuntimeDestroyed` listener for it and
+      // initialize the cache map.
+      RuntimeLifecycleMonitor::addListener(rt, this);
 
-        T cache;
-        _secondaryRuntimeCaches.emplace(&rt, std::move(cache));
-      }
+      T cache;
+      _runtimeCaches.emplace(&rt, std::move(cache));
     }
-    return _secondaryRuntimeCaches.at(&rt);
+    return _runtimeCaches.at(&rt);
   }
 
 private:
-  std::unordered_map<void *, T> _secondaryRuntimeCaches;
-  T _primaryCache;
+  std::unordered_map<jsi::Runtime *, T> _runtimeCaches;
 };
 
 } // namespace RNWorklet

--- a/cpp/base/WKTRuntimeAwareCache.h
+++ b/cpp/base/WKTRuntimeAwareCache.h
@@ -40,8 +40,8 @@ public:
 
   T &get(jsi::Runtime &rt) {
     if (_runtimeCaches.count(&rt) == 0) {
-      // This is the first time this Runtime has been accessed,
-      // set up a `onRuntimeDestroyed` listener for it and
+      // This is the first time this Runtime has been accessed.
+      // We set up a `onRuntimeDestroyed` listener for it and
       // initialize the cache map.
       RuntimeLifecycleMonitor::addListener(rt, this);
 


### PR DESCRIPTION
Fixes #166 

This PR changes `RuntimeAwareCache` to also treat the main JS Runtime like any other Runtime. Before, it could happen that the main JS Runtime was refreshed and destroyed, and it's cache (`_primaryCache`) went stale. 

Now we could also explicitly delete the `_primaryCache` when the main JS runtime gets deleted somehow, but I feel like that's almost going to be the identical code to the secondary runtime part then so might make more sense to just have one path that works for all runtimes.

Cache lookups are performed like normal, listeners are attached, and cache is cleared when it is destroyed.

---

@chrfalch I am not sure if I understood your code properly since you explicitly added comments there explaining why it was treated differently from other runtimes, but I haven't found an issue with my change yet. Am I missing something?

```
 * In order to provide an efficient implementation that does not add an overhead
 * for the cases when only a single runtiome is used, which is the primary
 * usecase, the following assumption has been made: Only for secondary runtimes
 * we track destruction and clean up the store associated with that runtime. For
 * the first runtime we assume that the object holding the store is destroyed
 * prior to the destruction of that runtime.
 ```
 
 I guess this is mainly about performance, right?

I think in our case, we only use this for our Worklets objects or Shared Values anyways - which are kinda assumed to be accessed between Runtimes? So I guess the performance impact here is fair?