### PR TITLE
feat: Throw errors when trying to use deprecated APIs

### DIFF
--- a/cpp/WKTJsiWorkletApi.h
+++ b/cpp/WKTJsiWorkletApi.h
@@ -92,6 +92,22 @@ public:
     return func.call(runtime, nullptr, 0);
   }
 
+  JSI_HOST_FUNCTION(createRunInJsFn) {
+    // TODO: Remove these deprecated APIs after one or two versions.
+    throw jsi::JSError(runtime,
+                       "Worklets.createRunInJsFn(..) has been deprecated in "
+                       "favor of Worklets.createRunOnJS(..) or "
+                       "Worklets.runOnJS(..) - please migrate to the new API!");
+  }
+
+  JSI_HOST_FUNCTION(createRunInContextFn) {
+    // TODO: Remove these deprecated APIs after one or two versions.
+    throw jsi::JSError(runtime,
+                       "Worklets.createRunInContextFn(context, ..) has been "
+                       "deprecated in favor of context.createRunAsync(..) or "
+                       "context.runAsync(..) - please migrate to the new API!");
+  }
+
   JSI_HOST_FUNCTION(__jsi_is_array) {
     if (count == 0) {
       throw jsi::JSError(runtime, "__getTypeIsArray expects one parameter.");
@@ -123,6 +139,10 @@ public:
                        JSI_EXPORT_FUNC(JsiWorkletApi, createContext),
                        JSI_EXPORT_FUNC(JsiWorkletApi, createRunOnJS),
                        JSI_EXPORT_FUNC(JsiWorkletApi, runOnJS),
+                       JSI_EXPORT_FUNC(JsiWorkletApi,
+                                       createRunInContextFn), // <-- deprecated
+                       JSI_EXPORT_FUNC(JsiWorkletApi,
+                                       createRunInJsFn), // <-- deprecated
                        JSI_EXPORT_FUNC(JsiWorkletApi, __jsi_is_array),
                        JSI_EXPORT_FUNC(JsiWorkletApi, __jsi_is_object))
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -99,6 +99,15 @@ export interface IWorkletNativeApi {
   createSharedValue: <T>(value: T) => ISharedValue<T>;
 
   /**
+   * @deprecated This API has been deprecated, use {@linkcode IWorkletContext.createRunAsync()} instead
+   */
+  createRunInContextFn: never;
+  /**
+   * @deprecated This API has been deprecated, use {@linkcode createRunOnJS()} instead
+   */
+  createRunInJsFn: never;
+
+  /**
    * Creates a function that can be executed asynchronously on the default React-JS context.
    *
    * The resulting function is memoized, so this is merely just a bit more efficient than {@linkcode runOnJS}.


### PR DESCRIPTION
Instead of just silently removing `createRunInJsFn` and `createRunInContextFn`, I added those methods back but they just throw an error about the deprecation notice instead.