### PR TITLE
feat: Add `Worklets.getCurrentThreadId()`

### DIFF
--- a/cpp/WKTJsiWorkletApi.h
+++ b/cpp/WKTJsiWorkletApi.h
@@ -4,6 +4,7 @@
 
 #include <memory>
 #include <string>
+#include <sstream>
 #include <thread>
 #include <vector>
 
@@ -95,9 +96,10 @@ public:
 
   JSI_HOST_FUNCTION(getCurrentThreadId) {
     std::thread::id threadId = std::this_thread::get_id();
-    std::hash<std::thread::id> hasher;
-    std::size_t id_hash = hasher(threadId);
-    return jsi::Value(static_cast<double>(id_hash));
+    std::stringstream stream;
+    stream << threadId;
+    std::string string = stream.str();
+    return jsi::String::createFromUtf8(runtime, string);
   }
 
   JSI_HOST_FUNCTION(__jsi_is_array) {

--- a/cpp/WKTJsiWorkletApi.h
+++ b/cpp/WKTJsiWorkletApi.h
@@ -3,8 +3,8 @@
 #include <jsi/jsi.h>
 
 #include <memory>
-#include <string>
 #include <sstream>
+#include <string>
 #include <thread>
 #include <vector>
 

--- a/cpp/WKTJsiWorkletApi.h
+++ b/cpp/WKTJsiWorkletApi.h
@@ -4,8 +4,8 @@
 
 #include <memory>
 #include <string>
-#include <vector>
 #include <thread>
+#include <vector>
 
 #include "WKTJsiHostObject.h"
 #include "WKTJsiJsDecorator.h"
@@ -92,7 +92,7 @@ public:
     jsi::Function func = value.asObject(runtime).asFunction(runtime);
     return func.call(runtime, nullptr, 0);
   }
-  
+
   JSI_HOST_FUNCTION(getCurrentThreadId) {
     std::thread::id threadId = std::this_thread::get_id();
     std::hash<std::thread::id> hasher;

--- a/cpp/WKTJsiWorkletApi.h
+++ b/cpp/WKTJsiWorkletApi.h
@@ -131,6 +131,7 @@ public:
                        JSI_EXPORT_FUNC(JsiWorkletApi, createContext),
                        JSI_EXPORT_FUNC(JsiWorkletApi, createRunOnJS),
                        JSI_EXPORT_FUNC(JsiWorkletApi, runOnJS),
+                       JSI_EXPORT_FUNC(JsiWorkletApi, getCurrentThreadId),
                        JSI_EXPORT_FUNC(JsiWorkletApi, __jsi_is_array),
                        JSI_EXPORT_FUNC(JsiWorkletApi, __jsi_is_object))
 

--- a/cpp/WKTJsiWorkletApi.h
+++ b/cpp/WKTJsiWorkletApi.h
@@ -5,6 +5,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include <thread>
 
 #include "WKTJsiHostObject.h"
 #include "WKTJsiJsDecorator.h"
@@ -90,6 +91,13 @@ public:
     jsi::Value value = createRunOnJS(runtime, thisValue, arguments, count);
     jsi::Function func = value.asObject(runtime).asFunction(runtime);
     return func.call(runtime, nullptr, 0);
+  }
+  
+  JSI_HOST_FUNCTION(getCurrentThreadId) {
+    std::thread::id threadId = std::this_thread::get_id();
+    std::hash<std::thread::id> hasher;
+    std::size_t id_hash = hasher(threadId);
+    return jsi::Value(static_cast<double>(id_hash));
   }
 
   JSI_HOST_FUNCTION(__jsi_is_array) {

--- a/example/Tests/worklet-tests.ts
+++ b/example/Tests/worklet-tests.ts
@@ -121,7 +121,7 @@ export const worklet_tests = {
   },
   check_thread_id_exists: () => {
     const threadId = Worklets.getCurrentThreadId();
-    return ExpectValue(Number.isSafeInteger(threadId), true);
+    return ExpectValue(threadId.length > 0, true);
   },
   check_thread_id_consecutive_calls_are_equal: () => {
     const first = Worklets.getCurrentThreadId();

--- a/example/Tests/worklet-tests.ts
+++ b/example/Tests/worklet-tests.ts
@@ -119,6 +119,32 @@ export const worklet_tests = {
     const w = Worklets.defaultContext.createRunAsync(f);
     return ExpectValue(w(), true);
   },
+  check_thread_id_exists: () => {
+    const threadId = Worklets.getCurrentThreadId();
+    return ExpectValue(Number.isSafeInteger(threadId), true);
+  },
+  check_thread_id_consecutive_calls_are_equal: () => {
+    const first = Worklets.getCurrentThreadId();
+    const second = Worklets.getCurrentThreadId();
+    return ExpectValue(first, second);
+  },
+  check_thread_id_consecutive_calls_in_worklet_are_equal: async () => {
+    const [first, second] = await Worklets.defaultContext.runAsync(() => {
+      "worklet";
+      const firstId = Worklets.getCurrentThreadId();
+      const secondId = Worklets.getCurrentThreadId();
+      return [firstId, secondId];
+    });
+    return ExpectValue(first, second);
+  },
+  check_thread_ids_are_different: async () => {
+    const jsThreadId = Worklets.getCurrentThreadId();
+    const workletThreadId = await Worklets.defaultContext.runAsync(() => {
+      "worklet";
+      return Worklets.getCurrentThreadId();
+    });
+    return await ExpectValue(jsThreadId !== workletThreadId, true);
+  },
   check_pure_array_is_passed_as_jsi_array: () => {
     const array = [0, 1, 2, 3, 4];
     const f = () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -137,6 +137,10 @@ export interface IWorkletNativeApi {
   runOnJS: <T>(func: () => T) => Promise<T>;
 
   /**
+   * Returns the current C++ Thread ID this method was called on.
+   */
+  getCurrentThreadId(): number;
+  /**
    * Get the default Worklet context.
    */
   defaultContext: IWorkletContext;

--- a/src/types.ts
+++ b/src/types.ts
@@ -139,7 +139,7 @@ export interface IWorkletNativeApi {
   /**
    * Returns the current C++ Thread ID this method was called on.
    */
-  getCurrentThreadId(): number;
+  getCurrentThreadId(): string;
   /**
    * Get the default Worklet context.
    */


### PR DESCRIPTION
Adds a new API: `Worklets.getCurrentThreadId()`

This API is useful for checking the C++ Thread ID, as that might differ between runs on Worklets if they use a modern Dispatch Queue (iOS; DispatchQueue, Android; Executor).
getCurrentThreadId() can be used to identify thread local cache, especially in graphics environments like OpenGL or Metal (Skia).

It can also be used for debugging.