### PR TITLE
fix: Use `thread_local` storage to increment `getCurrentThreadId()`

### DIFF
--- a/cpp/WKTJsiWorkletApi.h
+++ b/cpp/WKTJsiWorkletApi.h
@@ -3,7 +3,6 @@
 #include <jsi/jsi.h>
 
 #include <memory>
-#include <sstream>
 #include <string>
 #include <thread>
 #include <vector>
@@ -109,13 +108,14 @@ public:
                        "deprecated in favor of context.createRunAsync(..) or "
                        "context.runAsync(..) - please migrate to the new API!");
   }
-    
+
   JSI_HOST_FUNCTION(getCurrentThreadId) {
-    std::thread::id threadId = std::this_thread::get_id();
-    std::stringstream stream;
-    stream << threadId;
-    std::string string = stream.str();
-    return jsi::String::createFromUtf8(runtime, string);
+    static int threadCounter = 0;
+    static thread_local int thisThreadId = -1;
+    if (thisThreadId == -1) {
+      thisThreadId = threadCounter++;
+    }
+    return jsi::Value(thisThreadId);
   }
 
   JSI_HOST_FUNCTION(__jsi_is_array) {

--- a/example/Tests/worklet-tests.ts
+++ b/example/Tests/worklet-tests.ts
@@ -121,7 +121,7 @@ export const worklet_tests = {
   },
   check_thread_id_exists: () => {
     const threadId = Worklets.getCurrentThreadId();
-    return ExpectValue(threadId.length > 0, true);
+    return ExpectValue(Number.isSafeInteger(threadId), true);
   },
   check_thread_id_consecutive_calls_are_equal: () => {
     const first = Worklets.getCurrentThreadId();

--- a/src/types.ts
+++ b/src/types.ts
@@ -146,9 +146,12 @@ export interface IWorkletNativeApi {
   runOnJS: <T>(func: () => T) => Promise<T>;
 
   /**
-   * Returns the current C++ Thread ID this method was called on.
+   * Returns a unique identifier for the Thread this method is called on.
+   *
+   * Thread-IDs start at 0 and use `thread_local` storage to store their IDs
+   * which are incremented everytime a new Thread calls `getCurrentThreadId()`.
    */
-  getCurrentThreadId(): string;
+  getCurrentThreadId(): number;
   /**
    * Get the default Worklet context.
    */


### PR DESCRIPTION
This PR changes the implementation of `Worklets.getCurrentThreadId()` to not use [`std::this_thread::get_id()`](https://en.cppreference.com/w/cpp/thread/get_id), but instead just manually count IDs using a `thread_local` variable per Thread.

This also means that thread IDs are now numbers (int) instead of strings (hex).

The problem with `this_thread::get_id()` was that after a Thread has been terminated and a new thread has started, it might have the same `thread::id` as the one that was terminated, but the `thread_local` storage of that Thread has been wiped.
Skia uses `thread_local` storage, and the whole reason for that API is to find out which Thread's `thread_local` storage we are on, so the alternative is much more senseful here.