### PR TITLE
fix(jsc): prevent crashes when using jsc runtime

### DIFF
--- a/cpp/WKTJsiWorkletContext.cpp
+++ b/cpp/WKTJsiWorkletContext.cpp
@@ -219,8 +219,9 @@ JsiWorkletContext::createCallInContext(jsi::Runtime &runtime,
     // Start by wrapping the arguments
     ArgumentsWrapper argsWrapper(runtime, arguments, count);
 
-    // Wrap the this value
-    auto thisWrapper = JsiWrapper::wrap(runtime, thisValue);
+    // In hermes-engine, "thisValue" appears to always be an undefined value, but in jsc it's the globalThis object...
+    // It's just easier to wrap an undefined and provide that as the "this" context.
+    auto thisWrapper = JsiWrapper::wrap(runtime, jsi::Value::undefined());
 
     // If we are calling directly from/to the JS context or within the same
     // context, we can just dispatch everything directly.

--- a/cpp/WKTJsiWorkletContext.cpp
+++ b/cpp/WKTJsiWorkletContext.cpp
@@ -219,9 +219,8 @@ JsiWorkletContext::createCallInContext(jsi::Runtime &runtime,
     // Start by wrapping the arguments
     ArgumentsWrapper argsWrapper(runtime, arguments, count);
 
-    // In hermes-engine, "thisValue" appears to always be an undefined value, but in jsc it's the globalThis object...
-    // It's just easier to wrap an undefined and provide that as the "this" context.
-    auto thisWrapper = JsiWrapper::wrap(runtime, jsi::Value::undefined());
+    // Wrap the this value
+    auto thisWrapper = JsiWrapper::wrap(runtime, thisValue);
 
     // If we are calling directly from/to the JS context or within the same
     // context, we can just dispatch everything directly.

--- a/cpp/wrappers/WKTJsiObjectWrapper.h
+++ b/cpp/wrappers/WKTJsiObjectWrapper.h
@@ -60,9 +60,13 @@ public:
     } else {
       setObjectValue(runtime, object);
     }
+// NativeState functionality is also available in JSC with react-native 74+, but let's just keep this simple for now
+#if JS_RUNTIME_HERMES
     updateNativeState(runtime, object);
+#endif
   }
-
+                           
+#if JS_RUNTIME_HERMES
   void updateNativeState(jsi::Runtime &runtime, jsi::Object &obj) {
     if (obj.hasNativeState(runtime)) {
       _nativeState = obj.getNativeState(runtime);
@@ -70,6 +74,7 @@ public:
       _nativeState = nullptr;
     }
   }
+#endif
 
   /**
    * Overridden get value where we convert from the internal representation to
@@ -87,9 +92,11 @@ public:
     }
 
     jsi::Object obj = getObject(runtime);
+#if JS_RUNTIME_HERMES
     if (_nativeState != nullptr) {
       obj.setNativeState(runtime, _nativeState);
     }
+#endif
     return obj;
   }
 
@@ -250,6 +257,8 @@ private:
   std::map<std::string, std::shared_ptr<JsiWrapper>> _properties;
   std::shared_ptr<jsi::HostFunctionType> _hostFunction;
   std::shared_ptr<jsi::HostObject> _hostObject;
+#if JS_RUNTIME_HERMES
   std::shared_ptr<jsi::NativeState> _nativeState;
+#endif
 };
 } // namespace RNWorklet


### PR DESCRIPTION
While trying to get this library working in an environment where we are unable to use hermes for 𝓇ℯ𝒶𝓈ℴ𝓃𝓈, I encountered two issues which this PR fixes.

1. NativeState is unimplemented in the react-native JSC shim before react-native 0.74.x.
2. ~~When hostFunctions are called, JSC attempts to provide globalThis as the 'this' context causing crashes (hermes provides `undefined`).~~

Should hopefully resolve https://github.com/margelo/react-native-worklets-core/issues/137

As far as I can tell, the entire test suite passes in iOS. It seems like it's also passing in android but I am unable to get consistent results.