### PR TITLE
fix: Add lock when building the property names array in JsiObjectWrapper

### DIFF
--- a/cpp/wrappers/WKTJsiObjectWrapper.h
+++ b/cpp/wrappers/WKTJsiObjectWrapper.h
@@ -155,6 +155,8 @@ public:
    */
   std::vector<jsi::PropNameID>
   getPropertyNames(jsi::Runtime &runtime) override {
+    std::unique_lock lock(_readWriteMutex);
+    
     std::vector<jsi::PropNameID> retVal;
     retVal.reserve(_properties.size());
     for (auto it = _properties.begin(); it != _properties.end(); it++) {


### PR DESCRIPTION
To avoid someone modifying the object wrapper from one thread while we're enumerating it we need to create a lock on the object.