### PR TITLE
fix: Added support for changing type when setting prop

### DIFF
--- a/cpp/wrappers/WKTJsiObjectWrapper.h
+++ b/cpp/wrappers/WKTJsiObjectWrapper.h
@@ -121,13 +121,11 @@ public:
     std::unique_lock lock(_readWriteMutex);
 
     auto nameStr = name.utf8(runtime);
-    if (_properties.count(nameStr) == 0) {
-      _properties.emplace(
-          nameStr,
-          JsiWrapper::wrap(runtime, value, this, getUseProxiesForUnwrapping()));
-    } else {
-      _properties.at(nameStr)->updateValue(runtime, value);
-    }
+    // Just emplace so that we can box property values, ie. a slot can
+    // hold both an object and an int if that's what we need.
+    _properties.emplace(
+        nameStr,
+        JsiWrapper::wrap(runtime, value, this, getUseProxiesForUnwrapping()));
   }
 
   /**

--- a/example/Tests/sharedvalue-tests.ts
+++ b/example/Tests/sharedvalue-tests.ts
@@ -188,4 +188,11 @@ export const sharedvalue_tests = {
     });
     return ExpectValue(w(), true);
   },
+
+  set_object_property_to_undefined_after_being_an_object: () => {
+    const sharedValue = Worklets.createSharedValue({ a: { b: 200 } });
+    // @ts-ignore
+    sharedValue.value.a = undefined;
+    return Promise.resolve();
+  },
 };


### PR DESCRIPTION
Setting a property with different types used to fail:

```js
const sharedValue = Worklets.createSharedValue({ a: { b: 200 } });
sharedValue.value.a = undefined; // <- This failed
```

This fixes this issue.