### PR TITLE
Adding some tests for checking the spreading behaviour of objects returned by a worklet.

### DIFF
--- a/example/Tests/worklet-tests.ts
+++ b/example/Tests/worklet-tests.ts
@@ -215,6 +215,15 @@ export const worklet_tests = {
     const assignedObject = Object.assign({}, result);
     return ExpectValue(assignedObject, { a: 100 });
   },
+  check_jsi_object_is_spreadable_inside_worklet: async () => {
+    const func = () => {
+      "worklet";
+      const testObject = { a: 100, b: "200" };
+      return { ...testObject };
+    };
+    const result = Worklets.defaultContext.runAsync(func);
+    return ExpectValue(result, { a: 100, b: "200" });
+  },
   check_jsi_object_is_returned_from_worklet: async () => {
     const func = () => {
       "worklet";


### PR DESCRIPTION
The added `check_jsi_object_is_returned_from_worklet` test passes to show that the correct object is returned. It might be redundant compared the current main, I have not done an exhaustive check there.

However, in contrast - but on top of the previous test - the two newly added tests `check_jsi_object_is_spreadable_after_worklet` and `check_jsi_object_is_assignable_after_worklet` fail, showing that neither spread syntax nor `Object.assign()` can be used with the returned "object".