### PR TITLE
fix: Allowing fields on a shared value object to be reassigned

### DIFF
--- a/cpp/wrappers/WKTJsiObjectWrapper.h
+++ b/cpp/wrappers/WKTJsiObjectWrapper.h
@@ -65,7 +65,7 @@ public:
     updateNativeState(runtime, object);
 #endif
   }
-                           
+
 #if JS_RUNTIME_HERMES
   void updateNativeState(jsi::Runtime &runtime, jsi::Object &obj) {
     if (obj.hasNativeState(runtime)) {
@@ -128,11 +128,7 @@ public:
     std::unique_lock lock(_readWriteMutex);
 
     auto nameStr = name.utf8(runtime);
-    // Just emplace so that we can box property values, ie. a slot can
-    // hold both an object and an int if that's what we need.
-    _properties.emplace(
-        nameStr,
-        JsiWrapper::wrap(runtime, value, this, getUseProxiesForUnwrapping()));
+    _properties[nameStr] = JsiWrapper::wrap(runtime, value, this, getUseProxiesForUnwrapping());
   }
 
   /**
@@ -161,7 +157,7 @@ public:
   std::vector<jsi::PropNameID>
   getPropertyNames(jsi::Runtime &runtime) override {
     std::unique_lock lock(_readWriteMutex);
-    
+
     std::vector<jsi::PropNameID> retVal;
     retVal.reserve(_properties.size());
     for (auto it = _properties.begin(); it != _properties.end(); it++) {

--- a/example/Tests/sharedvalue-tests.ts
+++ b/example/Tests/sharedvalue-tests.ts
@@ -193,6 +193,6 @@ export const sharedvalue_tests = {
     const sharedValue = Worklets.createSharedValue({ a: { b: 200 } });
     // @ts-ignore
     sharedValue.value.a = undefined;
-    return Promise.resolve();
+    return ExpectValue(sharedValue.value, { a: undefined });
   },
 };


### PR DESCRIPTION
Fixing bug preventing fields on a shared value object from being reassigned. `map::emplace` does not allow overwriting the value for a key that already exists.

Attempting to fix an issue I opened a couple hours ago: https://github.com/margelo/react-native-worklets-core/issues/182