### PR TITLE
fix: Added missing lock

### DIFF
--- a/cpp/wrappers/WKTJsiObjectWrapper.h
+++ b/cpp/wrappers/WKTJsiObjectWrapper.h
@@ -198,6 +198,8 @@ private:
   }
 
   void setObjectValue(jsi::Runtime &runtime, jsi::Object &obj) {
+    std::unique_lock lock(_readWriteMutex);
+    
     setType(JsiWrapperType::Object);
     _properties.clear();
     auto propNames = obj.getPropertyNames(runtime);


### PR DESCRIPTION
JsiObjectWrapper: When setting value in setObjectValue we forgot to lock and this might give us the dreaded getPropertyNames error?

All methods that updates or changes the _properties variable MUST use a lock.