### PR TITLE
Add `worklet()` func that throws if value is not a worklet

### DIFF
--- a/example/Tests/worklet-tests.ts
+++ b/example/Tests/worklet-tests.ts
@@ -1,4 +1,4 @@
-import { Worklets } from "react-native-worklets-core";
+import { worklet, Worklets } from "react-native-worklets-core";
 import { ExpectException, ExpectValue, getWorkletInfo } from "./utils";
 
 export const worklet_tests = {
@@ -196,5 +196,21 @@ export const worklet_tests = {
       return 42;
     });
     return ExpectValue(result, 42);
+  },
+  check_worklet_checker_works: () => {
+    const func = () => {
+      "worklet";
+      return 42;
+    };
+    const same = worklet(func);
+    return ExpectValue(same, func);
+  },
+  check_worklet_checker_throws_invalid_worklet: () => {
+    const func = () => {
+      return "not a worklet";
+    };
+    return ExpectException(() => {
+      worklet(func);
+    });
   },
 };

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import {
   ScrollView,
   StyleSheet,
@@ -6,6 +6,7 @@ import {
   TouchableOpacity,
   View,
 } from "react-native";
+import { useWorklet } from "react-native-worklets-core";
 
 import { useTestRunner } from "../Tests";
 import { TestWrapper } from "../Tests/TestWrapper";
@@ -13,6 +14,17 @@ import { TestWrapper } from "../Tests/TestWrapper";
 const App = () => {
   const { tests, categories, output, runTests, runSingleTest } =
     useTestRunner();
+
+  const dummyWorklet = useWorklet("default", (name: string): number => {
+    "worklet";
+    console.log(`useWorklet(${name}) called!`);
+    return name.length;
+  });
+
+  useEffect(() => {
+    dummyWorklet("marc");
+  }, [dummyWorklet]);
+
   return (
     <View style={styles.container}>
       <View style={styles.tests}>

--- a/src/hooks/useWorklet.ts
+++ b/src/hooks/useWorklet.ts
@@ -1,39 +1,33 @@
-import { DependencyList, useMemo } from "react";
-import type { IWorkletContext } from "src/types";
+import { useMemo } from "react";
+import type { IWorkletContext } from "../types";
+import { worklet } from "../worklet";
 
 /**
- * Create a Worklet function that persists between re-renders.
+ * Create a Worklet function that automatically memoizes itself using it's auto-captured closure.
  * The returned function can be called from both a Worklet context and the JS context, but will execute on a Worklet context.
  *
  * @worklet
  * @param context The context to run this Worklet in. Can be `default` to use the default background context, or a custom context.
  * @param callback The Worklet. Must be marked with the `'worklet'` directive.
- * @param dependencyList The React dependencies of this Worklet.
  * @returns A memoized Worklet
  * ```ts
  * const sayHello = useWorklet('default', (name: string) => {
  *   'worklet'
  *   console.log(`Hello ${name}, I am running on the Worklet Thread!`)
- * }, [])
+ * })
  * sayHello()
  * ```
  */
 export function useWorklet<T extends (...args: any[]) => any>(
   context: IWorkletContext | "default",
-  callback: T,
-  dependencyList: DependencyList
+  callback: T
 ): (...args: Parameters<T>) => Promise<ReturnType<T>> {
-  const worklet = useMemo(
-    () => {
-      if (context === "default") {
-        return Worklets.defaultContext.createRunAsync(callback);
-      } else {
-        return context.createRunAsync(callback);
-      }
-    },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    dependencyList
-  );
+  const func = worklet(callback);
+  const ctx = context === "default" ? Worklets.defaultContext : context;
 
-  return worklet;
+  return useMemo(
+    () => ctx.createRunAsync(func),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [...Object.values(func.__closure), ctx]
+  );
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import "./NativeWorklets";
 export * from "./types";
+export * from "./worklet";
 export * from "./hooks/useRunOnJS";
 export * from "./hooks/useSharedValue";
 export * from "./hooks/useWorklet";

--- a/src/worklet.ts
+++ b/src/worklet.ts
@@ -1,12 +1,13 @@
 type AnyFunc = (...args: any[]) => any;
 
 type Workletize<TFunc extends () => any> = TFunc & {
+  __closure: Record<string, unknown>;
   __initData: {
     code: string;
     location: string;
     __sourceMap: string;
   };
-  __workletHash: string;
+  __workletHash: number;
 };
 
 /**
@@ -16,9 +17,11 @@ export function isWorklet<TFunc extends AnyFunc>(
   func: TFunc
 ): func is Workletize<TFunc> {
   const maybeWorklet = func as Partial<Workletize<TFunc>> & TFunc;
+  if (typeof maybeWorklet.__workletHash !== "number") return false;
+
   if (
-    maybeWorklet.__workletHash == null ||
-    typeof maybeWorklet.__workletHash !== "string"
+    maybeWorklet.__closure == null ||
+    typeof maybeWorklet.__closure !== "object"
   )
     return false;
 

--- a/src/worklet.ts
+++ b/src/worklet.ts
@@ -9,6 +9,11 @@ type Workletize<TFunc extends () => any> = TFunc & {
   };
   __workletHash: number;
 };
+const EXPECTED_KEYS: (keyof Workletize<AnyFunc>)[] = [
+  "__closure",
+  "__initData",
+  "__workletHash",
+];
 
 /**
  * Checks whether the given function is a Worklet or not.
@@ -40,15 +45,20 @@ export function isWorklet<TFunc extends AnyFunc>(
 
 class NotAWorkletError<TFunc extends AnyFunc> extends Error {
   constructor(func: TFunc) {
+    let funcName = func.name;
+    if (funcName.length === 0) {
+      funcName = func.toString();
+    }
+
+    const expected = `[${EXPECTED_KEYS.join(", ")}]`;
+    const received = `[${Object.keys(func).join(", ")}]`;
     super(
-      `The given function ("${func.name}") is not a Worklet! ` +
+      `The function "${funcName}" is not a Worklet! \n` +
+        `- Make sure the function "${funcName}" is decorated with the 'worklet' directive! \n` +
         `- Make sure react-native-worklets-core is installed properly! \n` +
         `- Make sure to add the react-native-worklets-core babel plugin to your babel.config.js! \n` +
         `- Make sure that no other plugin overrides the react-native-worklets-core babel plugin! \n` +
-        `- Make sure the function ${func.name} is decorated with the 'worklet' directive! \n` +
-        `Expected ${func.name} to contain __workletHash and __initData, but ${
-          func.name
-        } has these properties: ${Object.keys(func)}`
+        `Expected "${funcName}" to contain ${expected}, but "${funcName}" only has these properties: ${received}`
     );
   }
 }

--- a/src/worklet.ts
+++ b/src/worklet.ts
@@ -1,0 +1,65 @@
+type AnyFunc = (...args: any[]) => any;
+
+type Workletize<TFunc extends () => any> = TFunc & {
+  __initData: {
+    code: string;
+    location: string;
+    __sourceMap: string;
+  };
+  __workletHash: string;
+};
+
+/**
+ * Checks whether the given function is a Worklet or not.
+ */
+export function isWorklet<TFunc extends AnyFunc>(
+  func: TFunc
+): func is Workletize<TFunc> {
+  const maybeWorklet = func as Partial<Workletize<TFunc>> & TFunc;
+  if (
+    maybeWorklet.__workletHash == null ||
+    typeof maybeWorklet.__workletHash !== "string"
+  )
+    return false;
+
+  const initData = maybeWorklet.__initData;
+  if (initData == null || typeof initData !== "object") return false;
+
+  if (
+    typeof initData.__sourceMap !== "string" ||
+    typeof initData.code !== "string" ||
+    typeof initData.location !== "string"
+  )
+    return false;
+
+  return true;
+}
+
+class NotAWorkletError<TFunc extends AnyFunc> extends Error {
+  constructor(func: TFunc) {
+    super(
+      `The given function ("${func.name}") is not a Worklet! ` +
+        `- Make sure react-native-worklets-core is installed properly! \n` +
+        `- Make sure to add the react-native-worklets-core babel plugin to your babel.config.js! \n` +
+        `- Make sure that no other plugin overrides the react-native-worklets-core babel plugin! \n` +
+        `- Make sure the function ${func.name} is decorated with the 'worklet' directive! \n` +
+        `Expected ${func.name} to contain __workletHash and __initData, but ${
+          func.name
+        } has these properties: ${Object.keys(func)}`
+    );
+  }
+}
+
+/**
+ * Ensures the given function is a Worklet, and throws an error if not.
+ * @param func The function that should be a Worklet.
+ * @returns The same function that was passed in.
+ */
+export function worklet<TFunc extends () => any>(
+  func: TFunc
+): Workletize<TFunc> {
+  if (!isWorklet(func)) {
+    throw new NotAWorkletError(func);
+  }
+  return func;
+}


### PR DESCRIPTION
Adds the `worklet(...)` and `isWorklet(..)` functions:

### `worklet(...)`

```ts
const func = worklet(() => {
  'worklet'
  return "hello!"
})
context.runAsync(func)
```

This will do some runtime checking to ensure the given function is a worklet (uses `__initData`, `__closure` and `__workletHash`) and throws with some useful debugging information if it isn't. 

I will use this in VisionCamera's `useFrameProcessor` function to make sure people pass in worklets (funcs with `'worklet'` directive) and they installed the babel plugin properly. Otherwise the error is a bit cryptic, with this it's more clear what went wrong:

```diff
- ERROR  Error: The given function ("") is not a Worklet!
- - Make sure react-native-worklets-core is installed properly! 
- - Make sure to add the react-native-worklets-core babel plugin to your babel.config.js! 
- - Make sure that no other plugin overrides the react-native-worklets-core babel plugin! 
- - Make sure the function  is decorated with the 'worklet' directive! 
- Expected  to contain __workletHash and __initData, but  has these properties: 
- 
- This error is located at:
-     in App
-     in RCTView (created by View)
-     in View (created by AppContainer)
-     in RCTView (created by View)
-     in View (created by AppContainer)
-     in AppContainer
-     in WorkletsExample(RootComponent), js engine: hermes
```

Also, the returned type is useful because you can now safely access `func.__workletHash` or `func.__closure`.

### `isWorklet(...)`

Same thing as `worklet(...)`, but only returns false if the function is not a worklet instead of throwing an error.

### Changes to `useWorklet(..)`

The `useWorklet` hook now uses `worklet(..)` underneath to ensure the user passed in a correct Worklet.

Also, I now removed the `dependencies` parameter by automatically using the values in `func.__closure` for the `useMemo`'s dependencies. This is pretty cool because people often forgot to the hook dependencies in `useFrameProcessor` and wondered why it didn't update/re-build after a re-render.

