### PR TITLE
feat: Some typing improvements (`IWorklet`/`IWorkletize<>`)

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import {
   ScrollView,
   StyleSheet,
@@ -15,15 +15,20 @@ const App = () => {
   const { tests, categories, output, runTests, runSingleTest } =
     useTestRunner();
 
+  const [age, setAge] = useState(15);
   const dummyWorklet = useWorklet("default", (name: string): number => {
     "worklet";
     console.log(`useWorklet(${name}) called!`);
-    return name.length;
+    return name.length + age;
   });
 
   useEffect(() => {
     dummyWorklet("marc");
   }, [dummyWorklet]);
+
+  useEffect(() => {
+    setTimeout(() => setAge((a) => a * 2), 2000);
+  }, []);
 
   return (
     <View style={styles.container}>

--- a/src/NativeWorklets.ts
+++ b/src/NativeWorklets.ts
@@ -1,5 +1,6 @@
 import type { TurboModule } from "react-native";
 import { TurboModuleRegistry } from "react-native";
+import type { IWorkletNativeApi } from "./types";
 
 export interface Spec extends TurboModule {
   install(): boolean;
@@ -32,3 +33,6 @@ if (global.Worklets === undefined || global.Worklets == null) {
 } else {
   console.log("react-native-worklets-core installed.");
 }
+
+// @ts-expect-error It's a global injected by JSI.
+export const Worklets = global.Worklets as IWorkletNativeApi;

--- a/src/NativeWorklets.ts
+++ b/src/NativeWorklets.ts
@@ -10,7 +10,8 @@ const WorkletsInstaller = TurboModuleRegistry.getEnforcing<Spec>("Worklets");
 
 console.log("Loading react-native-worklets-core...");
 
-if (global.Worklets === undefined || global.Worklets == null) {
+// @ts-expect-error it's an untyped JSI global.
+if (global.Worklets == null) {
   if (
     WorkletsInstaller == null ||
     typeof WorkletsInstaller.install !== "function"

--- a/src/hooks/useRunOnJS.ts
+++ b/src/hooks/useRunOnJS.ts
@@ -1,4 +1,5 @@
 import { DependencyList, useMemo } from "react";
+import { Worklets } from "../NativeWorklets";
 
 /**
  * Create a Worklet function that runs the given function on the JS context.

--- a/src/hooks/useSharedValue.ts
+++ b/src/hooks/useSharedValue.ts
@@ -1,5 +1,6 @@
 import { useRef } from "react";
 import type { ISharedValue } from "../types";
+import { Worklets } from "../NativeWorklets";
 
 /**
  * Create a Shared Value that persists between re-renders.

--- a/src/hooks/useWorklet.ts
+++ b/src/hooks/useWorklet.ts
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 import type { IWorkletContext } from "../types";
 import { worklet } from "../worklet";
+import { Worklets } from "../NativeWorklets";
 
 /**
  * Create a Worklet function that automatically memoizes itself using it's auto-captured closure.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import "./NativeWorklets";
+export * from "./NativeWorklets";
 export * from "./types";
 export * from "./worklet";
 export * from "./hooks/useRunOnJS";

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,16 +11,41 @@ export interface ISharedValue<T> {
   addListener(listener: () => void): () => void;
 }
 
-export interface IWorklet {
+/**
+ * Represents the given function as a Worklet.
+ *
+ * Use the `worklet(...)` function to safely perform such casts with runtime checking.
+ */
+export type IWorklet<TFunc extends Function> = TFunc & {
   /**
-   * Returns the generated code for the worklet function.
+   * Contains an object of all captured values inside this Worklet.
+   *
+   * Primitives will be captured by (deep-)copy, and `SharedValues`, `HostObjects`
+   * or `HostFunctions` will be captured by reference.
    */
-  readonly code: string;
+  __closure: Record<string, unknown>;
   /**
-   * Returns true for worklets.
+   * Contains data that will be used to initialize a Worklet natively.
    */
-  readonly isWorklet: true;
-}
+  __initData: {
+    /**
+     * Contains the full JS code of the transpiled function with proper closure unwrapping.
+     */
+    code: string;
+    /**
+     * Contains the location of the function in the JS sources.
+     */
+    location: string;
+    /**
+     * Contains a source-code map of the Worklet to properly resolve stacktraces.
+     */
+    __sourceMap: string;
+  };
+  /**
+   * Holds a unique compile-time hash for the code and closure of this Worklet.
+   */
+  __workletHash: number;
+};
 
 /*
   Defines the interface for a worklet context. A worklet context is a javascript
@@ -153,8 +178,3 @@ export interface IWorkletNativeApi {
    */
   __jsi_is_object: <T>(value: T) => boolean;
 }
-declare global {
-  var Worklets: IWorkletNativeApi;
-}
-
-export const { Worklets } = globalThis;

--- a/src/types.ts
+++ b/src/types.ts
@@ -67,22 +67,6 @@ export interface IWorkletContext {
   runAsync: <T>(worklet: () => T) => Promise<T>;
 }
 
-export type ContextType = {
-  [key: string]:
-    | number
-    | string
-    | boolean
-    | undefined
-    | null
-    | ISharedValue<any>
-    | ContextType
-    | ContextType[]
-    | number[]
-    | string[]
-    | boolean[]
-    | IWorklet;
-};
-
 export interface IWorkletNativeApi {
   /**
    * Creates a new worklet context with the given name. The name identifies the

--- a/src/worklet.ts
+++ b/src/worklet.ts
@@ -1,6 +1,6 @@
 type AnyFunc = (...args: any[]) => any;
 
-type Workletize<TFunc extends () => any> = TFunc & {
+export type Workletize<TFunc extends AnyFunc> = TFunc & {
   __closure: Record<string, unknown>;
   __initData: {
     code: string;
@@ -9,6 +9,8 @@ type Workletize<TFunc extends () => any> = TFunc & {
   };
   __workletHash: number;
 };
+export type Worklet = Workletize<AnyFunc>;
+
 const EXPECTED_KEYS: (keyof Workletize<AnyFunc>)[] = [
   "__closure",
   "__initData",

--- a/src/worklet.ts
+++ b/src/worklet.ts
@@ -1,17 +1,6 @@
-type AnyFunc = (...args: any[]) => any;
+import type { IWorklet } from "./types";
 
-export type Workletize<TFunc extends AnyFunc> = TFunc & {
-  __closure: Record<string, unknown>;
-  __initData: {
-    code: string;
-    location: string;
-    __sourceMap: string;
-  };
-  __workletHash: number;
-};
-export type Worklet = Workletize<AnyFunc>;
-
-const EXPECTED_KEYS: (keyof Workletize<AnyFunc>)[] = [
+const EXPECTED_KEYS: (keyof IWorklet<Function>)[] = [
   "__closure",
   "__initData",
   "__workletHash",
@@ -20,10 +9,10 @@ const EXPECTED_KEYS: (keyof Workletize<AnyFunc>)[] = [
 /**
  * Checks whether the given function is a Worklet or not.
  */
-export function isWorklet<TFunc extends AnyFunc>(
+export function isWorklet<TFunc extends Function>(
   func: TFunc
-): func is Workletize<TFunc> {
-  const maybeWorklet = func as Partial<Workletize<TFunc>> & TFunc;
+): func is IWorklet<TFunc> {
+  const maybeWorklet = func as Partial<IWorklet<TFunc>> & TFunc;
   if (typeof maybeWorklet.__workletHash !== "number") return false;
 
   if (
@@ -45,7 +34,7 @@ export function isWorklet<TFunc extends AnyFunc>(
   return true;
 }
 
-class NotAWorkletError<TFunc extends AnyFunc> extends Error {
+class NotAWorkletError<TFunc extends Function> extends Error {
   constructor(func: TFunc) {
     let funcName = func.name;
     if (funcName.length === 0) {
@@ -70,7 +59,7 @@ class NotAWorkletError<TFunc extends AnyFunc> extends Error {
  * @param func The function that should be a Worklet.
  * @returns The same function that was passed in.
  */
-export function worklet<TFunc extends AnyFunc>(func: TFunc): Workletize<TFunc> {
+export function worklet<TFunc extends Function>(func: TFunc): IWorklet<TFunc> {
   if (!isWorklet(func)) {
     throw new NotAWorkletError(func);
   }


### PR DESCRIPTION
- Improves typings for `worklet(...)` and `isWorklet(...)`
- Always export `Worklets` instead of just declaring it in global (that will prevented the missing import error)
- Remove unused old types