### PR TITLE
repro: Add failing recursive object test

### DIFF
--- a/example/Tests/sharedvalue-tests.ts
+++ b/example/Tests/sharedvalue-tests.ts
@@ -39,6 +39,13 @@ export const sharedvalue_tests = {
     );
   },
 
+  get_set_recursive_value: () => {
+    const x = { a: 5, b: {} };
+    x.b = x;
+    const sharedValue = Worklets.createSharedValue(x);
+    return ExpectValue(sharedValue.value, x);
+  },
+
   is_object: () => {
     const sharedValue = Worklets.createSharedValue({ a: 100, b: 200 });
     return ExpectValue(typeof sharedValue.value === "object", true);


### PR DESCRIPTION
RNWC is currently struggling with recursive values. This issue was discovered when we passed a workout function directly to an `onPress` prop, which has an `event` argument, which is recursive. RNWC gets stuck in an endless loop:

 
![Screenshot 2024-05-10 at 12 25 14](https://github.com/margelo/react-native-worklets-core/assets/16821682/e2848aad-9bcd-469e-b835-4c1dd7d385eb)
