### PR TITLE
fix: fix recent incompatibility when using reanimated

### DIFF
--- a/cpp/WKTJsiWorklet.h
+++ b/cpp/WKTJsiWorklet.h
@@ -21,7 +21,7 @@ static const char *PropNameWorkletInitDataCode = "code";
 static const char *PropNameJsThis = "jsThis";
 
 static const char *PropNameWorkletInitDataLocation = "location";
-static const char *PropNameWorkletInitDataSourceMap = "__sourceMap";
+static const char *PropNameWorkletInitDataSourceMap = "sourceMap";
 
 static const char *PropNameWorkletLocation = "__location";
 static const char *PropNameWorkletAsString = "asString";

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -266,7 +266,7 @@ PODS:
   - React-jsinspector (0.71.2)
   - React-logger (0.71.2):
     - glog
-  - react-native-worklets-core (1.3.0):
+  - react-native-worklets-core (1.3.2):
     - React
     - React-callinvoker
     - React-Core
@@ -495,7 +495,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: c7e028406112db456ac3cf5720d266bc7bc20938
   React-jsinspector: ea8101acf525ec08b2d87ddf0637d45f8e3b4148
   React-logger: 97987f46779d8dd24656474ad0c43a5b459f31d6
-  react-native-worklets-core: 7a50c0c14005cc57df8583eabd99ea3f467fa277
+  react-native-worklets-core: ff4a4076ad86469e61ec8e39da2cb13c55da2385
   React-perflogger: c7ccda3d1d1da837f7ff4e54e816022a6803ee87
   React-RCTActionSheet: 01c125aebbad462a24228f68c584c7a921d6c28e
   React-RCTAnimation: 5277a9440acffc4a5b7baa6ae3880fe467277ae6
@@ -513,4 +513,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: fd46804085f978bcef56543628998164c7956884
 
-COCOAPODS: 1.14.3
+COCOAPODS: 1.12.1

--- a/src/plugin/index.js
+++ b/src/plugin/index.js
@@ -517,7 +517,7 @@ function makeWorklet(t, fun, state) {
   if (sourceMapString) {
     initDataObjectExpression.properties.push(
       t.objectProperty(
-        t.identifier("__sourceMap"),
+        t.identifier("sourceMap"),
         t.stringLiteral(sourceMapString)
       )
     );

--- a/src/types.ts
+++ b/src/types.ts
@@ -39,7 +39,7 @@ export type IWorklet<TFunc extends Function> = TFunc & {
     /**
      * Contains a source-code map of the Worklet to properly resolve stacktraces.
      */
-    __sourceMap: string;
+    sourceMap: string;
   };
   /**
    * Holds a unique compile-time hash for the code and closure of this Worklet.

--- a/src/worklet.ts
+++ b/src/worklet.ts
@@ -26,7 +26,7 @@ export function isWorklet<TFunc extends Function>(
   if (initData == null || typeof initData !== "object") return false;
 
   if (
-    typeof initData.__sourceMap !== "string" ||
+    typeof initData.sourceMap !== "string" ||
     typeof initData.code !== "string" ||
     typeof initData.location !== "string"
   )


### PR DESCRIPTION
Often times this library is used next to reanimated.
In this case the worklets are transpiled by the reanimated babel plugin.
The reanimated babel plugin uses `initData.sourceMap` instead of RNWC current `initData.__sourceMap`.
This has gone unnoticed so far, cause we never checked for that property.

In this PR, which was recently merged

- https://github.com/margelo/react-native-worklets-core/pull/188

a check was introduced, that checks if the provided function is a `worklet`:

https://github.com/margelo/react-native-worklets-core/blob/c495c52df85ec627c6c4d98aa785d20590322e80/src/hooks/useWorklet.ts#L6-L9

In this function we check for the `__sourceMap` identifier, which won't be present when we run with reanimated.

The solution to this seems to be to use the same identifier name as in reanimated. 

Without this change we will see this error with a stack where everything is a valid worklet:

![Simulator Screenshot - iPhone 15 Pro Max - 2024-05-10 at 18 42 56](https://github.com/margelo/react-native-worklets-core/assets/16821682/7e3a31c8-a420-4e76-a9e9-3987bff3b6c3)
