### PR TITLE
Add double context nested runAsync test on JS thread

### DIFF
--- a/example/Tests/worklet-context-tests.ts
+++ b/example/Tests/worklet-context-tests.ts
@@ -416,16 +416,17 @@ export const worklet_context_tests = {
     const a = Worklets.createSharedValue(10);
     const context = Worklets.createContext("nested-context-2");
     const context2 = Worklets.createContext("nested-context-3")
+    const innerFunc = context2.createRunAsync(() => {
+      "worklet";
+      a.value = a.value + 1;
+    });
     const result = Worklets.runOnJs(() => {
       "worklet";
       for(var i = 0; i < 20; i++) {
         context.runAsync(() => {
           "worklet";
           a.value = a.value + 1;
-          context2.runAsync(() => {
-            "worklet";
-            a.value = a.value + 1;
-          });
+          innerFunc()
         });
       }
     });

--- a/example/Tests/worklet-context-tests.ts
+++ b/example/Tests/worklet-context-tests.ts
@@ -412,4 +412,25 @@ export const worklet_context_tests = {
     });
     return ExpectValue(result, 1200);
   },
+  call_run_async_then_async_between_custom_context_many_times_in_js: () => {
+    const a = Worklets.createSharedValue(10);
+    const context = Worklets.createContext("nested-context-2");
+    const context2 = Worklets.createContext("nested-context-3")
+    const result = Worklets.runOnJs(() => {
+      "worklet";
+      for(var i = 0; i < 20; i++) {
+        context.runAsync(() => {
+          "worklet";
+          a.value = a.value + 1;
+          context2.runAsync(() => {
+            "worklet";
+            a.value = a.value + 1;
+          });
+        });
+      }
+    });
+    setTimeout(() => {
+      return ExpectValue(a.value, 50); // Let async calls finish
+    }, "3000");
+  },
 };


### PR DESCRIPTION
Mimics the useFrameProcessor which is a non default context using runAsync (different non default context). 

There is an issue where useFrameProcessor works with runAsync initially on iOS then stops. (Might be an issue with a dereference of a pointer)