### PR TITLE
fix: Fix `podspec` dependency (`RCTTurboModule not found` error)

### DIFF
--- a/react-native-worklets-core.podspec
+++ b/react-native-worklets-core.podspec
@@ -30,7 +30,7 @@ Pod::Spec.new do |s|
     s.dependency "RCT-Folly"
     s.dependency "RCTRequired"
     s.dependency "RCTTypeSafety"
-    s.dependency "ReactCommon/turbomodule/core"
+    s.dependency "React"
   else
     s.pod_target_xcconfig = {
       'CLANG_CXX_LANGUAGE_STANDARD' => 'c++17',


### PR DESCRIPTION
Fixes this error:

![image](https://github.com/user-attachments/assets/5b4e4c23-0a04-4a75-8be4-2ff3a607f823)
