### PR TITLE
Support using Nitro Modules in Worklets contexts (WIP)

### DIFF
--- a/cpp/wrappers/WKTJsiObjectWrapper.h
+++ b/cpp/wrappers/WKTJsiObjectWrapper.h
@@ -93,7 +93,7 @@ public:
      }
      jsi::Object prototypeObject = prototype.getObject(runtime);
      _prototype = std::make_shared<JsiObjectWrapper>(nullptr, false);
-     _prototype->setValue(runtime, jsi::Value(runtime, object));
+     _prototype->setValue(runtime, jsi::Value(runtime, prototypeObject));
    }
 
   /**

--- a/cpp/wrappers/WKTJsiWrapper.cpp
+++ b/cpp/wrappers/WKTJsiWrapper.cpp
@@ -21,6 +21,8 @@ jsi::Value JsiWrapper::getValue(jsi::Runtime &runtime) {
     return jsi::Value(static_cast<double>(_numberValue));
   case JsiWrapperType::String:
     return jsi::String::createFromUtf8(runtime, _stringValue);
+  case JsiWrapperType::BigInt:
+    return jsi::BigInt::fromInt64(runtime, _bigintValue);
   default:
     throw jsi::JSError(runtime, "Value type not supported.");
     return jsi::Value::undefined();
@@ -34,7 +36,7 @@ std::shared_ptr<JsiWrapper> JsiWrapper::wrap(jsi::Runtime &runtime,
   std::shared_ptr<JsiWrapper> retVal = nullptr;
 
   if (value.isUndefined() || value.isNull() || value.isBool() ||
-      value.isNumber() || value.isString()) {
+      value.isNumber() || value.isBigInt() || value.isString()) {
     retVal = std::make_shared<JsiWrapper>(parent, useProxiesForUnwrapping);
   } else if (value.isObject()) {
     auto obj = value.asObject(runtime);
@@ -74,6 +76,9 @@ void JsiWrapper::setValue(jsi::Runtime &runtime, const jsi::Value &value) {
   } else if (value.isString()) {
     _type = JsiWrapperType::String;
     _stringValue = value.asString(runtime).utf8(runtime);
+  } else if (value.isBigInt()) {
+    _type = JsiWrapperType::BigInt;
+    _bigintValue = value.getBigInt(runtime).asInt64(runtime);
   } else {
     throw jsi::JSError(runtime, "Value type not supported.");
   }

--- a/cpp/wrappers/WKTJsiWrapper.h
+++ b/cpp/wrappers/WKTJsiWrapper.h
@@ -20,6 +20,7 @@ enum JsiWrapperType {
   Bool,
   Number,
   String,
+  BigInt,
   Array,
   Object,
   Promise,
@@ -239,6 +240,7 @@ private:
   bool _boolValue;
   double _numberValue;
   std::string _stringValue;
+  int64_t _bigintValue;
 
   size_t _listenerId = 1000;
   std::map<size_t, std::shared_ptr<std::function<void()>>> _listeners;


### PR DESCRIPTION
Adds support for using Nitro Modules in a Worklet context.

This means, you can use any kind of module from a different Thread/Runtime.

It should essentially be a light copy since all native functions are HostFunctions that can just be copied over to a new Prototype.