### PR TITLE
fix(ios): #209 build enable stricter header search paths

### DIFF
--- a/package/example/ios/Podfile.lock
+++ b/package/example/ios/Podfile.lock
@@ -1397,7 +1397,7 @@ SPEC CHECKSUMS:
   glog: c5d68082e772fa1c511173d6b30a9de2c05a69a2
   hermes-engine: 16b8530de1b383cdada1476cf52d1b52f0692cbc
   RCT-Folly: 02617c592a293bd6d418e0a88ff4ee1f88329b47
-  RCTDeprecation: 4dc9c8fbcb15bc9e8f3cfa601ddc190e120f099b
+  RCTDeprecation: efb313d8126259e9294dc4ee0002f44a6f676aba
   RCTRequired: f49ea29cece52aee20db633ae7edc4b271435562
   RCTTypeSafety: a11979ff0570d230d74de9f604f7d19692157bc4
   React: 88794fad7f460349dbc9df8a274d95f37a009f5d
@@ -1420,7 +1420,7 @@ SPEC CHECKSUMS:
   React-jsitracing: 233d1a798fe0ff33b8e630b8f00f62c4a8115fbc
   React-logger: 7e7403a2b14c97f847d90763af76b84b152b6fce
   React-Mapbuffer: 11029dcd47c5c9e057a4092ab9c2a8d10a496a33
-  react-native-worklets-core: f5cdd75d46976ffa253adce0701218313de9cf09
+  react-native-worklets-core: c010c5a4aca2bbb3ee6d0b4e386530e3354a597e
   React-nativeconfig: b0073a590774e8b35192fead188a36d1dca23dec
   React-NativeModulesApple: df46ff3e3de5b842b30b4ca8a6caae6d7c8ab09f
   React-perflogger: 3d31e0d1e8ad891e43a09ac70b7b17a79773003a
@@ -1450,4 +1450,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: dd279d8753229b5dae73274420e8f0d67725614a
 
-COCOAPODS: 1.12.1
+COCOAPODS: 1.15.2

--- a/package/react-native-worklets-core.podspec
+++ b/package/react-native-worklets-core.podspec
@@ -17,6 +17,7 @@ Pod::Spec.new do |s|
   s.pod_target_xcconfig = {
     "CLANG_CXX_LANGUAGE_STANDARD" => "c++17",
     "CLANG_CXX_LIBRARY" => "libc++",
+    "DEFINES_MODULE" => "YES",
   }
   s.source_files = [
     # iOS Installer


### PR DESCRIPTION
see: https://blog.cocoapods.org/CocoaPods-1.5.0/
    
fixes this error specifically: https://github.com/margelo/react-native-worklets-core/issues/209

there is no real downside to enabling this flag, so should be fine