### PR TITLE
fix(ios): fix install problems on new arch

### DIFF
--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -64,7 +64,7 @@ jobs:
             ~/.cocoapods
           key: ${{ runner.os }}-pods-${{ hashFiles('**/Podfile.lock') }}
       - name: Install Pods
-        run: RCT_NEW_ARCH_ENABLED=0 bundle exec pod install
+        run: RCT_NEW_ARCH_ENABLED=1 bundle exec pod install
       - name: Install xcpretty
         run: gem install xcpretty
       - name: Build App

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -32,7 +32,7 @@ reactNativeArchitectures=armeabi-v7a,arm64-v8a,x86,x86_64
 # your application. You should enable this flag either if you want
 # to write custom TurboModules/Fabric components OR use libraries that
 # are providing them.
-newArchEnabled=false
+newArchEnabled=true
 
 # Use this property to enable or disable the Hermes JS engine.
 # If set to false, you will be using JSC instead.

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1243,9 +1243,26 @@ PODS:
     - ReactCommon/turbomodule/core
     - Yoga
   - react-native-worklets-core (1.3.3):
-    - React
-    - React-callinvoker
+    - DoubleConversion
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.01.01.00)
+    - RCTRequired
+    - RCTTypeSafety
     - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - Yoga
   - React-nativeconfig (0.76.1)
   - React-NativeModulesApple (0.76.1):
     - glog
@@ -1736,16 +1753,16 @@ SPEC CHECKSUMS:
   React-CoreModules: b4437acf2ef25ce3689c84df661dc5d806559b35
   React-cxxreact: 6125cd820da7e18f9ca8343b3c42ee61634a4e0d
   React-debug: f474f5c202a277f76c81bf7cf26284f2c09880d7
-  React-defaultsnativemodule: 05f1a83669c4f01b5761b58ca0968306c99f3d50
-  React-domnativemodule: 64f3f5089cf214c31aa1821dd8fd4abc481baa91
+  React-defaultsnativemodule: 7141fa704531cbf7a7e7af3bc02adfa367e831a7
+  React-domnativemodule: c1806b8584a53ed912012a4d8b2c6f96a84c77a3
   React-Fabric: ba9636cfc7f9b77df6cb7edb2c70d0237026404b
   React-FabricComponents: c408da05a4ea5ba071732245b4a7f48f904e610a
   React-FabricImage: c409858f319f11709b49ffa6c5bca4faf794cb44
   React-featureflags: 929732439d139ac0662e08f009f1a51ed2b91ed3
-  React-featureflagsnativemodule: 2f899ad011b6b1a8aa8babe4fafa0a68725faeb6
+  React-featureflagsnativemodule: 02dd903d4cbe4fae0e6cd02bc32a09d30543282f
   React-graphics: a5cad35307286e9f83e212834e95fef4010d03d0
   React-hermes: 14aafa9630579b84c2167b563bdb8c811970a03e
-  React-idlecallbacksnativemodule: ba1475765a2900e1adc76ce45a625ef5f79fdc19
+  React-idlecallbacksnativemodule: 69581ac44bd355acce3739c3fe380c0f6d7a6d09
   React-ImageManager: 41945afb3ace0c52255057ec4ae6af6f5a23539f
   React-jserrorhandler: ecbc4622df7ab3d0066a4313cde4172d45745508
   React-jsi: ff383df87c7047e976a66be45df59e4e0db5346e
@@ -1754,17 +1771,17 @@ SPEC CHECKSUMS:
   React-jsitracing: 654f4d9cb9fd99b3d96f239ceb215ae49ce28ac0
   React-logger: 97c9dafae1f1a638001a9d1d0e93d431f2f9cb7b
   React-Mapbuffer: 3146a13424f9fec2ea1f1462d49d566e4d69b732
-  React-microtasksnativemodule: 8fa0a3d8542f6ae7712deebe0802ee17a623718b
-  react-native-worklets-core: f51430dd07bf5343d4918d28a4bb00fe8f98b982
+  React-microtasksnativemodule: 02d218c79c72d373a92a8552183f4ead0d1c6e05
+  react-native-worklets-core: afbb9d49d00bc19ba55518aa2f3abf1c53ebcfd5
   React-nativeconfig: 93fe8c85a8c40820c57814e30f3e44b94c995a7b
   React-NativeModulesApple: b3e076fd0d7b73417fe1e8c8b26e3c57ae9b74aa
   React-perflogger: 1c55bcd3c392137cbaf0d21d8bb87ce9a0cebb15
   React-performancetimeline: e89249db10b8f7bf8f72c2e9bd471ac37d48b753
   React-RCTActionSheet: 9407c795fbeee35da2dae3cd6b5c4e5da6ff8bd3
   React-RCTAnimation: 7ee1c2a77aab7e5c568611d8092a994cfcbe8410
-  React-RCTAppDelegate: e7b835203804bfd12a8baad30ab4c67f7da7bf24
+  React-RCTAppDelegate: 10c2b0c434baf5a71b53d5c86c4d8d0dbd6bb380
   React-RCTBlob: 761072706300d22624ec2d6bf860b77d95ebd3da
-  React-RCTFabric: a6c44c606009f889ef7431e71f03c5339fb72e6e
+  React-RCTFabric: 871d38933a94554d9e27963aa4bb67184dc7529e
   React-RCTImage: b6614fde902ec9647f15236da94df2d24c40523f
   React-RCTLinking: 25950eda5d5f786bfb3daf513ea7d848555a2a93
   React-RCTNetwork: b69407c4119fd7a1cc07db4a94563f2546f8770d

--- a/example/package.json
+++ b/example/package.json
@@ -6,8 +6,7 @@
     "android": "react-native run-android",
     "ios": "react-native run-ios",
     "start": "react-native start",
-    "pods": "bundle install && cd ios && RCT_NEW_ARCH_ENABLED=0 bundle exec pod install && cd ..",
-    "pods-new-arch": "RCT_NEW_ARCH_ENABLED=1 pod-install --quiet"
+    "pods": "bundle install && cd ios && RCT_NEW_ARCH_ENABLED=1 bundle exec pod install && cd .."
   },
   "dependencies": {
     "react": "18.3.1",

--- a/react-native-worklets-core.podspec
+++ b/react-native-worklets-core.podspec
@@ -15,32 +15,9 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/margelo/react-native-worklets-core.git", :tag => "#{s.version}" }
 
   s.source_files = "ios/**/*.{h,m,mm}", "cpp/**/*.{h,cpp}"
+  s.pod_target_xcconfig = {
+    "DEFINES_MODULE" => "YES",
+  }
 
-  s.dependency "React-Core"
-
-  # Don't install the dependencies when we run `pod install` in the old architecture.
-  if ENV['RCT_NEW_ARCH_ENABLED'] == '1' then
-    s.compiler_flags = folly_compiler_flags + " -DRCT_NEW_ARCH_ENABLED=1"
-    s.pod_target_xcconfig    = {
-        "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost\"",
-        "OTHER_CPLUSPLUSFLAGS" => "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1",
-        "CLANG_CXX_LANGUAGE_STANDARD" => "c++17"
-    }
-    s.dependency "React-Codegen"
-    s.dependency "RCT-Folly"
-    s.dependency "RCTRequired"
-    s.dependency "RCTTypeSafety"
-    s.dependency "ReactCommon/turbomodule/core"
-  else
-    s.pod_target_xcconfig = {
-      'CLANG_CXX_LANGUAGE_STANDARD' => 'c++17',
-      'DEFINES_MODULE' => 'YES',
-      "HEADER_SEARCH_PATHS" => "\"${PODS_ROOT}/Headers/Public/React-hermes\" \"${PODS_ROOT}/Headers/Public/hermes-engine\"",
-      "OTHER_CFLAGS" => "$(inherited)"
-    }
-
-    s.dependency "React-callinvoker"
-    s.dependency "React"
-    s.dependency "React-Core"
-  end
+  install_modules_dependencies(s)
 end


### PR DESCRIPTION
RNWC already has a code path for new arch on iOS and on android its already a Turbo Module package, so thats all fine.
For iOS we had to fix the podspec though as otherwise you would get build errors ([see here for reference](https://github.com/facebook/react-native/blob/e0be2efe4e80edf99f96a2ae6a25856f6df5e0ca/packages/react-native/scripts/cocoapods/new_architecture.rb#L71))

based on this PR which should be merged first:

- https://github.com/margelo/react-native-worklets-core/pull/224