### PR TITLE
fix: Fixes name clash with react-native-worklets

### DIFF
--- a/android/src/main/java/com/worklets/WorkletsCorePackage.java
+++ b/android/src/main/java/com/worklets/WorkletsCorePackage.java
@@ -13,7 +13,7 @@ import com.facebook.react.turbomodule.core.interfaces.TurboModule;
 import java.util.HashMap;
 import java.util.Map;
 
-public class WorkletsPackage extends TurboReactPackage {
+public class WorkletsCorePackage extends TurboReactPackage {
 
   @Nullable
   @Override


### PR DESCRIPTION
On android the worklets core package name clashes with reanimated's worklets. Renaming to WorkletsCorePackage fixes the issue. If one also has vision camera installed one needs to clean the android build files there as well.

Tested changes in my currnet project that use worklets-core, vision camera and reanimated 4 with worklets.