### PR TITLE
fix(android): build issues where dependent libraries can't link RNWC

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -51,6 +51,7 @@ def reactNativeArchitectures() {
 }
 
 apply plugin: "com.android.library"
+apply from: "./gradle/fix-prefab.gradle"
 
 if (isNewArchitectureEnabled()) {
     apply plugin: "com.facebook.react"
@@ -178,55 +179,5 @@ tasks.configureEach { task ->
   // C++ clean
   if (task.name.contains("clean")) {
     task.dependsOn(deleteCmakeCache)
-  }
-
-    // Make sure that we generate our prefab publication file only after having built the native library
-  // so that not a header publication file, but a full configuration publication will be generated, which
-  // will include the .so file
-
-  // TODO: this needs to be fixed to work dynamically on the variant name
-  if (task.name.contains("prefabDebugConfigurePackage")) {
-    task.outputs.upToDateWhen { false }
-    task.dependsOn("externalNativeBuildDebug")
-  }
-    if (task.name.contains("prefabReleaseConfigurePackage")) {
-      task.outputs.upToDateWhen { false }
-        task.dependsOn("externalNativeBuildRelease")
-    }
-}
-
-afterEvaluate {
-  def abis = reactNativeArchitectures()
-  rootProject.allprojects.each { proj ->
-    if (proj === rootProject) return // skip RNWC and app project
-
-
-    def dependsOnWorklets = proj.configurations.findAll { it.canBeResolved }.any { config ->
-      config.dependencies.any { dep ->
-        dep.group == project.group && dep.name == project.name
-      }
-    }
-    if (!dependsOnWorklets && proj != project) return // skip if not dependent
-    println("Project ${proj.path} depends on react-native-worklets-core")
-
-    if (proj.plugins.hasPlugin('com.android.application') || proj.plugins.hasPlugin('com.android.library')) {
-      def variants = proj.android.hasProperty('applicationVariants') ? proj.android.applicationVariants : proj.android.libraryVariants
-      variants.all { variant ->
-        def variantName = variant.name
-        abis.each { abi ->
-          def searchDir = new File(proj.projectDir, ".cxx/${variantName}")
-          if (!searchDir.exists()) return
-          def matches = []
-          searchDir.eachDir { randomDir ->
-            def prefabFile = new File(randomDir, "${abi}/prefab_config.json")
-            if (prefabFile.exists()) matches << prefabFile
-          }
-          matches.each { prefabConfig ->
-            prefabConfig.setLastModified(System.currentTimeMillis())
-            println("Touched: ${prefabConfig}")
-          }
-        }
-      }
-    }
   }
 }

--- a/android/gradle/fix-prefab.gradle
+++ b/android/gradle/fix-prefab.gradle
@@ -1,0 +1,51 @@
+tasks.configureEach { task ->
+  // Make sure that we generate our prefab publication file only after having built the native library
+  // so that not a header publication file, but a full configuration publication will be generated, which
+  // will include the .so file
+
+  def prefabConfigurePattern = ~/^prefab(.+)ConfigurePackage$/
+  def matcher = task.name =~ prefabConfigurePattern
+  if (matcher.matches()) {
+    def variantName = matcher[0][1]
+    task.outputs.upToDateWhen { false }
+    task.dependsOn("externalNativeBuild${variantName}")
+  }
+}
+
+afterEvaluate {
+  def abis = reactNativeArchitectures()
+  rootProject.allprojects.each { proj ->
+    if (proj === rootProject) return
+
+    def dependsOnThisLib = proj.configurations.findAll { it.canBeResolved }.any { config ->
+      config.dependencies.any { dep ->
+        dep.group == project.group && dep.name == project.name
+      }
+    }
+    if (!dependsOnThisLib && proj != project) return
+
+    if (!proj.plugins.hasPlugin('com.android.application') && !proj.plugins.hasPlugin('com.android.library')) {
+      return
+    }
+
+    def variants = proj.android.hasProperty('applicationVariants') ? proj.android.applicationVariants : proj.android.libraryVariants
+    // Touch the prefab_config.json files to ensure that in ExternalNativeJsonGenerator.kt we will re-trigger the prefab CLI to
+    // generate a libnameConfig.cmake file that will contain our native library (.so).
+    // See this condition: https://cs.android.com/android-studio/platform/tools/base/+/mirror-goog-studio-main:build-system/gradle-core/src/main/java/com/android/build/gradle/tasks/ExternalNativeJsonGenerator.kt;l=207-219?q=createPrefabBuildSystemGlue
+    variants.all { variant ->
+      def variantName = variant.name
+      abis.each { abi ->
+        def searchDir = new File(proj.projectDir, ".cxx/${variantName}")
+        if (!searchDir.exists()) return
+        def matches = []
+        searchDir.eachDir { randomDir ->
+          def prefabFile = new File(randomDir, "${abi}/prefab_config.json")
+          if (prefabFile.exists()) matches << prefabFile
+        }
+        matches.each { prefabConfig ->
+          prefabConfig.setLastModified(System.currentTimeMillis())
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Basically addresses all bugs such as:

- https://github.com/mrousavy/nitro/issues/674
- https://github.com/mrousavy/nitro/issues/674
- https://github.com/margelo/react-native-worklets-core/issues/235
- https://github.com/margelo/react-native-worklets-core/issues/242
- https://github.com/mrousavy/react-native-vision-camera/issues/3425
- https://github.com/mrousavy/react-native-vision-camera/issues/3551

## Details:

There is a bug with the gradle android plugin that causes libraries that depend on the prefab we publish to not be able to find the native libraries.

There are two problems to why this bug occurs:

1. The `prefabConfigurePackage` task might run before we build our native libaries. This will cause AGP to treat our library as a "header only" library, in that case it generates a CMake file, which doesn't include the native library and thus linking fails.
   - Special note: the AGP always creates a header publication file when we run `configureCMake`,there is no way to avoid that.
2. There are cases where AGP for a dependent library already ran the prefab CLI when for this library we only had the header publication.
   Even when the publication in our library changes (because native libs were build) the _dependent_ library wouldn't pick up on that change, as the only place where the AGP would re-run the prefab CLI (which generates the cmake file) is [here](https://cs.android.com/android-studio/platform/tools/base/+/mirror-goog-studio-main:build-system/gradle-core/src/main/java/com/android/build/gradle/tasks/ExternalNativeJsonGenerator.kt;l=207-219?q=createPrefabBuildSystemGlue).
   However, no changes are detected, although our prefab publication changed. Thus we manually touch a file to mark it as changed, and that will trigger the CLI to run

## Notes:

- This fix needs to be cherry-picked to v2 of RNWC as well (not sure though how many people use it)
- Other libraries that use prefab mechanisms such as nitro-modules have to implement this as well
