### PR TITLE
fix: prevent auto-install ndk version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -72,6 +72,10 @@ task deleteCmakeCache() {
 android {
   compileSdkVersion getExtOrIntegerDefault("compileSdkVersion")
 
+  if (rootProject.hasProperty("ndkVersion")) {
+    ndkVersion rootProject.ext.ndkVersion
+  }
+
   defaultConfig {
     minSdkVersion getExtOrIntegerDefault("minSdkVersion")
     targetSdkVersion getExtOrIntegerDefault("targetSdkVersion")


### PR DESCRIPTION
this package should at least respect root-level ndk versions and not try to install ndks because some build environments using Nix for example do not allow download+install operations at build time

if root project specifies a version, we should trust it is available and not auto-install another version

- ref https://github.com/margelo/react-native-worklets-core/issues/259

without this patch i get a build error:

```
> Configure project :react-native-worklets-core
Checking the license for package NDK (Side by side) 27.0.12077973 in /nix/store/a67rqhs5jm5892sjmgxgwinj27qljdxa-android-sdk-env/share/android-sdk/licenses
License for package NDK (Side by side) 27.0.12077973 accepted.
Preparing "Install NDK (Side by side) 27.0.12077973 v.27.0.12077973".
Warning: Failed to read or create install properties file.

FAILURE: Build failed with an exception.

* Where:
Build file '/.../node_modules/react-native-quick-crypto/android/build.gradle...

* What went wrong:
A problem occurred configuring project ':react-native-quick-crypto'.
> Could not create task ':react-native-quick-crypto:configureCMakeDebug[armeabi-v7a]'.
   > A problem occurred configuring project ':react-native-worklets-core'.
      > com.android.builder.sdk.InstallFailedException: Failed to install the following SDK components:
            ndk;27.0.12077973 NDK (Side by side) 27.0.12077973
        The SDK directory is not writable (/nix/store/a67rqhs5jm5892sjmgxgwinj27qljdxa-android-sdk-env/s...
```